### PR TITLE
4.0.0: Lenient SAN parser + move-API rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,39 @@ Releases from 3.3 onward. Earlier history is in git tags only.
 
 ## [4.0.0] - 2026-05-10
 
-Lenient SAN release. New parser pipeline accepts a defined set of forgivable deviations from canonical SAN; major API rename across move execution and parser entry points.
+Lenient SAN release. New parser pipeline accepts a defined set of forgivable deviations from canonical SAN; the move-execution and parser API is renamed across the board to make the strict / lenient axis explicit at every call site.
 
-### Breaking
-- `Board.performMove(String)` → `Board.moveStrict(String)`; now returns `StrictSanParserValidationResult` (the `MoveSpecification` is on the result) rather than `boolean`.
+### Breaking — move execution
+- `Board.performMove(String)` → `Board.moveStrict(String)`; now returns `StrictSanParserValidationResult` (the resolved `MoveSpecification` is on the result) rather than `boolean`.
 - `Board.performMove(MoveSpecification)` → `Board.move(MoveSpecification)`; still returns `boolean`.
 - `Board.performMoves(String...)` → `Board.movesStrict(String...)`; still returns `boolean`.
 - `Board.unperformMove()` → `Board.unmove()`.
-- New `Board.moveLenient(String)` returns `LenientSanParserValidationResult` carrying the move plus the list of forgiven SAN deviations.
-- `SanValidation` class renamed to `StrictSanParser`; entry-point method `validateSan(String, ChessBoard)` renamed to `parseText(String, ChessBoard)`; return type changed from `MoveSpecification` to `StrictSanParserValidationResult`.
+- New `Board.moveLenient(String)` returns `LenientSanParserValidationResult` carrying the resolved `MoveSpecification` together with the list of forgiven SAN deviations.
 - `ChessBoard` interface methods renamed to match (`move`, `moveStrict`, `moveLenient`, `movesStrict`, `unmove`).
 
+### Breaking — SAN parser
+- `SanValidation` renamed to `StrictSanParser`. Entry-point method `validateSan(String, ChessBoard)` renamed to `parseText(String, ChessBoard)`. Return type changed from `MoveSpecification` to `StrictSanParserValidationResult` (one-field record); to keep the prior shape, append `.moveSpecification()`.
+
+### Migration
+For most callers, the change is mechanical:
+| Before | After |
+|---|---|
+| `board.performMove("e4")` | `board.moveStrict("e4")` |
+| `board.performMove(moveSpec)` | `board.move(moveSpec)` |
+| `board.performMoves("e4", "e5")` | `board.movesStrict("e4", "e5")` |
+| `board.performMoveLenient("nf3")` | `board.moveLenient("nf3")` |
+| `board.unperformMove()` | `board.unmove()` |
+| `SanValidation.validateSan(san, board)` | `StrictSanParser.parseText(san, board).moveSpecification()` |
+
 ### Notable
-- New lenient SAN pipeline (`com.dlb.chess.san.lenient.LenientSanParser`) with a 21-code forgiven-item taxonomy: castling-with-zero, UCI / long-algebraic notation, explicit pawn letter, missing promotion equals, missing / spurious capture marker, six check / checkmate suffix mismatches, three over-specification cases, non-standard rank disambiguation, and four case-variation codes. Surfaces every accepted deviation as a typed `ForgivenItem` with the original token and canonical equivalent. See `specification.md` §3.3.1.
+- New lenient SAN pipeline (`com.dlb.chess.san.lenient.LenientSanParser`) with a 21-code forgiven-item taxonomy: castling-with-zero, UCI / long-algebraic notation, explicit pawn letter, missing promotion equals, missing / spurious capture marker, six check / checkmate suffix mismatches, three over-specification cases, non-standard rank disambiguation, and four case-variation codes. Every accepted deviation surfaces as a typed `ForgivenItem` with the original token and the canonical-SAN equivalent — consumers can silently accept or warn. See `specification.md` §3.3.1.
 - `LenientPgnParser` now wires the lenient SAN pipeline into the movetext path. `LenientPgnParserValidationResult` gains `pgnFile` and `sanForgivenItems` fields; `validateText` is now the rich entry point that returns the parsed file alongside the validation status.
+- `LenientSanParserValidationException` carries `GameStatus` so the `GAME_ALREADY_ENDED` propagation works end-to-end through the PGN layer.
 - PGN tokenizer recognises `0-0` / `0-0-0` as castling SAN tokens rather than (invalid) termination markers.
 - README "Lenient PGN parser" section documents the SAN tolerances with a worked example.
 
 ### Internal
-- Strict SAN pipeline reused unchanged for chess validation; the lenient layer is a thin input-shape transformer plus a strict-replay-with-recovery loop.
+- Strict SAN pipeline reused unchanged for chess validation; the lenient layer is a thin input-shape transformer plus a strict-replay-with-recovery loop. Deliberately not recovered: mixed `0-O` castling, pawn `SPURIOUS_CAPTURE_MARKER` (no clean string mutation; recovery would silently swap the user's intended pawn), and game-already-ended (top-of-pipeline guard, identical to strict).
 
 ## [3.3.0] - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,31 @@
 
 Releases from 3.3 onward. Earlier history is in git tags only.
 
-The project is pre-major — releases are intermediate stabilization steps until the library reaches feature-maturity. Detail level here is deliberately modest; once the library hits major, this file will be more complete.
-
 ## [Unreleased]
+
+## [4.0.0] - 2026-05-10
+
+Lenient SAN release. New parser pipeline accepts a defined set of forgivable deviations from canonical SAN; major API rename across move execution and parser entry points.
+
+### Breaking
+- `Board.performMove(String)` → `Board.moveStrict(String)`; now returns `StrictSanParserValidationResult` (the `MoveSpecification` is on the result) rather than `boolean`.
+- `Board.performMove(MoveSpecification)` → `Board.move(MoveSpecification)`; still returns `boolean`.
+- `Board.performMoves(String...)` → `Board.movesStrict(String...)`; still returns `boolean`.
+- `Board.unperformMove()` → `Board.unmove()`.
+- New `Board.moveLenient(String)` returns `LenientSanParserValidationResult` carrying the move plus the list of forgiven SAN deviations.
+- `SanValidation` class renamed to `StrictSanParser`; entry-point method `validateSan(String, ChessBoard)` renamed to `parseText(String, ChessBoard)`; return type changed from `MoveSpecification` to `StrictSanParserValidationResult`.
+- `ChessBoard` interface methods renamed to match (`move`, `moveStrict`, `moveLenient`, `movesStrict`, `unmove`).
+
+### Notable
+- New lenient SAN pipeline (`com.dlb.chess.san.lenient.LenientSanParser`) with a 21-code forgiven-item taxonomy: castling-with-zero, UCI / long-algebraic notation, explicit pawn letter, missing promotion equals, missing / spurious capture marker, six check / checkmate suffix mismatches, three over-specification cases, non-standard rank disambiguation, and four case-variation codes. Surfaces every accepted deviation as a typed `ForgivenItem` with the original token and canonical equivalent. See `specification.md` §3.3.1.
+- `LenientPgnParser` now wires the lenient SAN pipeline into the movetext path. `LenientPgnParserValidationResult` gains `pgnFile` and `sanForgivenItems` fields; `validateText` is now the rich entry point that returns the parsed file alongside the validation status.
+- PGN tokenizer recognises `0-0` / `0-0-0` as castling SAN tokens rather than (invalid) termination markers.
+- README "Lenient PGN parser" section documents the SAN tolerances with a worked example.
+
+### Internal
+- Strict SAN pipeline reused unchanged for chess validation; the lenient layer is a thin input-shape transformer plus a strict-replay-with-recovery loop.
+
+## [3.3.0] - 2026-05-09
 
 Cleanup follow-through release. Documentation, naming, packaging, and design-consistency polish across the library.
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ Positions can also often be dead due to forced moves.
 ### Lenient PGN parser
 The common PGN parser — reads the file with best effort. For example, the space after `[` below is ignored. See the [Not supported](#not-supported) section above for what neither parser accepts.
 
+In addition to structural tolerances (whitespace, missing tags, optional termination markers), the lenient parser accepts a defined set of SAN deviations from canonical — see [PGN SAN tolerances](#pgn-san-tolerances) below.
+
 #### PGN valid
 
 ```java
@@ -404,6 +406,41 @@ The parser does a bit more than a standard parser should do. It converts the imp
     // 1. e4 e5 2. Nf3 Nf6 3. Bc4 Bc5 *
     // 
 ```
+
+#### PGN SAN tolerances
+
+The lenient PGN parser accepts SAN moves that deviate from canonical SAN in any of the following ways. Each accepted deviation is surfaced as a typed `ForgivenItem` via `LenientPgnParserValidationResult.sanForgivenItems()`, so consumers can either silently accept or warn the user. The full taxonomy (21 codes) is documented in `specification.md` §3.3.1.
+
+- **Castling**: `0-0` / `0-0-0` (zero instead of letter O)
+- **Notation form**: long algebraic (`e2-e4`, `Nb1-d7`), UCI (`e2e4`, `e7e8q`, `e1g1` for castling), explicit pawn letter (`Pe4`)
+- **Disambiguation**: redundant file/rank/square (e.g. `Nbd7` when `Nd7` would suffice), non-canonical rank-instead-of-file (`R1d4` where canonical is `Rad4`)
+- **Capture marker**: missing (`Be5` when actually a capture) or spurious (`Bxe5` to an empty square)
+- **Check / mate suffix**: missing, spurious, or wrong (`Nd7+` when actually mate, `Nd7#` when only check, `Nd7` when actually check, etc.)
+- **Promotion**: missing `=` (`e8Q`)
+- **Case**: lowercase piece letter (`nf3`), uppercase file letter (`NF3`), uppercase capture marker (`BXe5`), lowercase promotion piece (`e8=q`)
+
+```java
+    final var pgn = """
+        [Event "?"]
+        [Site "?"]
+        [Date "?"]
+        [Round "?"]
+        [White "?"]
+        [Black "?"]
+        [Result "*"]
+
+        1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. 0-0 nf6 *
+                """;
+    final LenientPgnParserValidationResult result = LenientPgnParser.validateText(pgn);
+    System.out.println(result.isValid()); // true
+    for (final ForgivenItem item : result.sanForgivenItems()) {
+      System.out.println(item.code() + ": " + item.originalToken() + " -> " + item.canonicalSan());
+    }
+    // ZERO_INSTEAD_OF_O_CASTLING: 0-0 -> O-O
+    // LOWERCASE_PIECE_LETTER: nf6 -> Nf6
+```
+
+The strict pipeline that performs the actual chess validation is reused unchanged; the lenient layer only translates input shape and recovers from a defined set of strict rejections. A move that's not a legal chess move (regardless of how it was written) is still rejected.
 
 #### PGN invalid
 
@@ -588,12 +625,12 @@ Checks whether a PGN can be parsed using the PGN lenient parser.
 
         1. e4 e5   2. Nf3
         Nf6
-          3. Bc4 Bc5 4. X1
+          3. Bc4 Bc5 4. Y1
                 """;
     final LenientPgnParserValidationResult result = LenientPgnParser.validateText(pgn);
     System.out.println(result.isValid()); // false
     System.out.println(result.message());
-    // The movetext is invalid because a SAN contains an invalid character of "X".
+    // The movetext is invalid because a SAN contains an invalid character of "Y".
 ```
 
 #### File validation

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Requires JDK 17 or later at runtime. Available via the [JitPack](https://jitpack
 <dependency>
   <groupId>com.github.dlbbld</groupId>
   <artifactId>clean-chess</artifactId>
-  <version>3.3.0</version>
+  <version>4.0.0</version>
 </dependency>
 ```
 
@@ -56,7 +56,7 @@ repositories {
 ```groovy
 dependencies {
     ...
-    implementation 'com.github.dlbbld:clean-chess:3.3.0'
+    implementation 'com.github.dlbbld:clean-chess:4.0.0'
     ...
 }
 ```
@@ -75,15 +75,15 @@ For the full Eclipse contributor workflow (project import, Checkstyle, formatter
 ```java
   final Board board = new Board();
 
-  board.performMove("e4"); // specifying the SAN
-  board.performMoves("e5", "Bc4"); // specifying multiple SAN's
+  board.moveStrict("e4"); // specifying the SAN
+  board.movesStrict("e5", "Bc4"); // specifying multiple SAN's
 
   final var newMove = new MoveSpecification(Square.F8, Square.C5);
-  board.performMove(newMove); // move specification without SAN
+  board.move(newMove); // move specification without SAN
 
-  board.unperformMove(); // undoes last move
+  board.unmove(); // undoes last move
 
-  board.performMoves("Bc5", "Qf3", "h6", "Qxf7#");
+  board.movesStrict("Bc5", "Qf3", "h6", "Qxf7#");
 
   System.out.println(board.isCheckmate()); // true
 ```
@@ -374,7 +374,7 @@ In addition to structural tolerances (whitespace, missing tags, optional termina
 
     final PgnFile pgnFile = LenientPgnParser.parseText(pgn);
     final Board board = PgnUtility.calculateBoardPerLastMove(pgnFile);
-    board.performMove("a3");
+    board.moveStrict("a3");
 
 ```
 
@@ -495,7 +495,7 @@ The strict PGN parser does not allow inconsistencies as the lenient PGN parser. 
 
     final PgnFile pgnFile = StrictPgnParser.parseText(pgn);
     final Board board = PgnUtility.calculateBoardPerLastMove(pgnFile);
-    board.performMove("a3");
+    board.moveStrict("a3");
 ```
     
 #### PGN invalid syntax
@@ -555,7 +555,7 @@ You can create the PGN for a game played in the library or export an imported PG
 
 ```java
     final Board board = new Board();
-    board.performMoves("e4", "e5", "Nf3", "Nf6", "Bc4", "Bc5");
+    board.movesStrict("e4", "e5", "Nf3", "Nf6", "Bc4", "Bc5");
 
     final PgnFile pgnFile = PgnCreate.createPgnFile(board);
     System.out.println(PgnCreate.createPgnFileString(pgnFile));
@@ -577,7 +577,7 @@ The PGN is created in the unique export format as defined by the PGN specificati
 
 ```java
     final Board board = new Board();
-    board.performMoves("e4", "e5", "Nf3", "Nf6", "Bc4", "Bc5");
+    board.movesStrict("e4", "e5", "Nf3", "Nf6", "Bc4", "Bc5");
 
     final PgnFile pgnFile = PgnCreate.createPgnFile(board);
 
@@ -592,7 +592,7 @@ A PGN can be written to the file system as below.
 
 ```java
     final Board board = new Board();
-    board.performMoves("e4", "e5", "Nf3", "Nf6", "Bc4", "Bc5");
+    board.movesStrict("e4", "e5", "Nf3", "Nf6", "Bc4", "Bc5");
 
     final PgnFile pgnFile = PgnCreate.createPgnFile(board);
     PgnWriter.writePgnFile(pgnFile, "C:\\temp\\myFile.pgn");

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.dlbbld</groupId>
 	<artifactId>clean-chess</artifactId>
-	<version>3.3.0</version>
+	<version>4.0.0</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/specification.md
+++ b/specification.md
@@ -118,7 +118,7 @@ The lenient SAN pipeline (`LenientSanParser`, reached via `Board.performMoveLeni
 | | `SPURIOUS_CHECKMATE_SUFFIX` | `Nd7#` when not mate |
 | | `WRONG_CHECK_SUFFIX_FOR_CHECKMATE` | `Nd7+` when actually mate |
 | | `WRONG_CHECKMATE_SUFFIX_FOR_CHECK` | `Nd7#` when only check |
-| **Capture marker** (2) | `MISSING_CAPTURE_MARKER` | `Be5` when actually a capture |
+| **Capture marker** (2) | `MISSING_CAPTURE_MARKER` | `Be5` (piece) or `ed5` (pawn) when actually a capture |
 | | `SPURIOUS_CAPTURE_MARKER` | `Bxe5` when destination empty |
 | **Disambiguation** (4) | `OVERSPECIFIED_FILE_DISAMBIGUATION` | `Nbd7` when `Nd7` would suffice |
 | | `OVERSPECIFIED_RANK_DISAMBIGUATION` | `N3d7` when `Nd7` would suffice |

--- a/specification.md
+++ b/specification.md
@@ -96,15 +96,15 @@ Both variants are **opt-in**. clean-chess does not invoke CHA automatically when
 
 ### 3.3 SAN, FEN, PGN
 
-- **SAN** — two pipelines: **strict** (canonical SAN only; reached from `Board.performMove(String)` and from the PGN-driven path) and **lenient** (accepts a defined set of forgivable deviations from canonical; reached from `Board.performMoveLenient(String)`). See §3.3.1 for the lenient taxonomy and algorithm.
+- **SAN** — two pipelines: **strict** (canonical SAN only; reached from `Board.moveStrict(String)` and from the PGN-driven path) and **lenient** (accepts a defined set of forgivable deviations from canonical; reached from `Board.moveLenient(String)`). See §3.3.1 for the lenient taxonomy and algorithm.
 - **FEN** — basic parsing validates structure; *advanced* parsing additionally validates position legality (no impossible double-checks, achievable pawn structure, castling rights consistent with rooks-and-king positions, etc.). `Board(String fen)` uses the advanced variant, so a `Board` cannot be constructed from a position no real game could reach.
 - **PGN** — two parsers: **strict** (round-trip-canonical reference, enforces export-format invariants) and **lenient** (tolerates real-world PGN — spaced move-number indicators, missing seven-tag-roster entries, optional termination markers, extra whitespace). Both produce the same `PgnFile` model. The exporter (`PgnCreate`) aims for byte-stable round-trip with the strict parser. The two-parser split is deliberate: a single parser with a "strictness flag" inevitably grows conditional branches that obscure both rule sets — splitting keeps each parser readable and lets the two evolve independently.
 
 #### 3.3.1 Lenient SAN
 
-The strict SAN pipeline (`SanValidation`, reached via `Board.performMove(String)`) accepts only canonical SAN: file-preferred disambiguation, uppercase piece letter and lowercase file letter, the `=Q` promotion form, `O-O` / `O-O-O` castling, and an optional `+` / `#` suffix that must match the actual board state. Real-world PGN — ChessBase output, hand-edited files, engine traces — routinely deviates in forgivable ways.
+The strict SAN pipeline (`StrictSanParser`, reached via `Board.moveStrict(String)`) accepts only canonical SAN: file-preferred disambiguation, uppercase piece letter and lowercase file letter, the `=Q` promotion form, `O-O` / `O-O-O` castling, and an optional `+` / `#` suffix that must match the actual board state. Real-world PGN — ChessBase output, hand-edited files, engine traces — routinely deviates in forgivable ways.
 
-The lenient SAN pipeline (`LenientSanParser`, reached via `Board.performMoveLenient(String)`) accepts these deviations when they uniquely identify a legal move. Every accepted deviation surfaces as a typed `ForgivenItem` carrying the deviation code, the original token, and the canonical-SAN equivalent — so consumers can silently accept or warn.
+The lenient SAN pipeline (`LenientSanParser`, reached via `Board.moveLenient(String)`) accepts these deviations when they uniquely identify a legal move. Every accepted deviation surfaces as a typed `ForgivenItem` carrying the deviation code, the original token, and the canonical-SAN equivalent — so consumers can silently accept or warn.
 
 **Principle: canonical-first.** A string that already parses as canonical SAN never receives a different meaning under lenient — strict is tried first; only on rejection does the lenient layer engage. So `bxc6` always means pawn capture from the b-file, even if a bishop on the b-file could also capture on c6.
 
@@ -138,7 +138,7 @@ Codes are not collapsed: each distinguishable deviation has its own code, and a 
 
 **Algorithm — two-phase.** *Phase 1 (shape normalization)* performs pure-string transforms plus board-aware UCI translation (look up piece on from-square): castling-zero, mixed-castling rejection, `P`-stripping, hyphen-stripping (LAN), UCI form translation, missing-`=` insertion, all four case fixups. LAN and UCI are mutually exclusive at the input level — a hyphen means LAN (`LONG_ALGEBRAIC_NOTATION` only), no hyphen means UCI shape (`UCI_NOTATION` only). *Phase 2 (semantic recovery)* feeds the normalized candidate to the strict pipeline and, on a recoverable rejection (terminal-marker mismatch, capture-marker mismatch, over-specification, non-standard disambig), mutates the candidate and retries. Each lenient code can fire at most once per parse, bounding the loop.
 
-**API.** `LenientSanParser.parseText(String, ChessBoard)` returns a `LenientSanParserValidationResult` (move + forgiven items). `LenientSanParser.validateText(String, ChessBoard)` is the same call with the result discarded — convenience for yes/no checks. `Board.performMoveLenient(String)` returns the same result type so the convenience path also surfaces forgiven items.
+**API.** `LenientSanParser.parseText(String, ChessBoard)` returns a `LenientSanParserValidationResult` (move + forgiven items). `LenientSanParser.validateText(String, ChessBoard)` is the same call with the result discarded — convenience for yes/no checks. `Board.moveLenient(String)` returns the same result type so the convenience path also surfaces forgiven items.
 
 **Deliberate non-recoveries.** Three categories are rejected even by the lenient pipeline:
 - **Mixed castling** (`0-O`, `O-0`) — no real-world tool emits this; allowing it would add parser complexity for zero practical value.

--- a/specification.md
+++ b/specification.md
@@ -96,9 +96,56 @@ Both variants are **opt-in**. clean-chess does not invoke CHA automatically when
 
 ### 3.3 SAN, FEN, PGN
 
-- **SAN** — parsing, validation, and generation with canonical disambiguation. A single `Board.performMove(String)` validation is reached from both the programmatic and the PGN-driven paths.
+- **SAN** — two pipelines: **strict** (canonical SAN only; reached from `Board.performMove(String)` and from the PGN-driven path) and **lenient** (accepts a defined set of forgivable deviations from canonical; reached from `Board.performMoveLenient(String)`). See §3.3.1 for the lenient taxonomy and algorithm.
 - **FEN** — basic parsing validates structure; *advanced* parsing additionally validates position legality (no impossible double-checks, achievable pawn structure, castling rights consistent with rooks-and-king positions, etc.). `Board(String fen)` uses the advanced variant, so a `Board` cannot be constructed from a position no real game could reach.
 - **PGN** — two parsers: **strict** (round-trip-canonical reference, enforces export-format invariants) and **lenient** (tolerates real-world PGN — spaced move-number indicators, missing seven-tag-roster entries, optional termination markers, extra whitespace). Both produce the same `PgnFile` model. The exporter (`PgnCreate`) aims for byte-stable round-trip with the strict parser. The two-parser split is deliberate: a single parser with a "strictness flag" inevitably grows conditional branches that obscure both rule sets — splitting keeps each parser readable and lets the two evolve independently.
+
+#### 3.3.1 Lenient SAN
+
+The strict SAN pipeline (`SanValidation`, reached via `Board.performMove(String)`) accepts only canonical SAN: file-preferred disambiguation, uppercase piece letter and lowercase file letter, the `=Q` promotion form, `O-O` / `O-O-O` castling, and an optional `+` / `#` suffix that must match the actual board state. Real-world PGN — ChessBase output, hand-edited files, engine traces — routinely deviates in forgivable ways.
+
+The lenient SAN pipeline (`LenientSanParser`, reached via `Board.performMoveLenient(String)`) accepts these deviations when they uniquely identify a legal move. Every accepted deviation surfaces as a typed `ForgivenItem` carrying the deviation code, the original token, and the canonical-SAN equivalent — so consumers can silently accept or warn.
+
+**Principle: canonical-first.** A string that already parses as canonical SAN never receives a different meaning under lenient — strict is tried first; only on rejection does the lenient layer engage. So `bxc6` always means pawn capture from the b-file, even if a bishop on the b-file could also capture on c6.
+
+**Taxonomy — 21 codes** (`com.dlb.chess.san.enums.LenientSanValidationProblem`):
+
+| Category | Code | Example |
+|---|---|---|
+| **Suffix mismatch** (6) | `MISSING_CHECK_SUFFIX` | `Nd7` when actually check |
+| | `MISSING_CHECKMATE_SUFFIX` | `Nd7` when actually mate |
+| | `SPURIOUS_CHECK_SUFFIX` | `Nd7+` when not check |
+| | `SPURIOUS_CHECKMATE_SUFFIX` | `Nd7#` when not mate |
+| | `WRONG_CHECK_SUFFIX_FOR_CHECKMATE` | `Nd7+` when actually mate |
+| | `WRONG_CHECKMATE_SUFFIX_FOR_CHECK` | `Nd7#` when only check |
+| **Capture marker** (2) | `MISSING_CAPTURE_MARKER` | `Be5` when actually a capture |
+| | `SPURIOUS_CAPTURE_MARKER` | `Bxe5` when destination empty |
+| **Disambiguation** (4) | `OVERSPECIFIED_FILE_DISAMBIGUATION` | `Nbd7` when `Nd7` would suffice |
+| | `OVERSPECIFIED_RANK_DISAMBIGUATION` | `N3d7` when `Nd7` would suffice |
+| | `OVERSPECIFIED_SQUARE_DISAMBIGUATION` | `Nb3d7` when less would suffice |
+| | `NON_STANDARD_RANK_DISAMBIGUATION` | `R1d4` where canonical uses file (`Rad4`) |
+| **Notation form** (4) | `LONG_ALGEBRAIC_NOTATION` | `e2-e4`, `Nb1-d7` |
+| | `UCI_NOTATION` | `e2e4`, `e7e8q`, `e1g1` (castling) |
+| | `ZERO_INSTEAD_OF_O_CASTLING` | `0-0`, `0-0-0` |
+| | `EXPLICIT_PAWN_LETTER` | `Pe4` |
+| **Promotion form** (1) | `MISSING_PROMOTION_EQUALS` | `e8Q` |
+| **Case variation** (4) | `LOWERCASE_PIECE_LETTER` | `nf3` |
+| | `UPPERCASE_FILE_LETTER` | `NF3` |
+| | `UPPERCASE_CAPTURE_MARKER` | `BXe5` |
+| | `LOWERCASE_PROMOTION_PIECE` | `e8=q` |
+
+Codes are not collapsed: each distinguishable deviation has its own code, and a single move can carry multiple codes (e.g. `nbxd7+` when actually mate emits `LOWERCASE_PIECE_LETTER` + `OVERSPECIFIED_FILE_DISAMBIGUATION` + `WRONG_CHECK_SUFFIX_FOR_CHECKMATE`).
+
+**Algorithm — two-phase.** *Phase 1 (shape normalization)* performs pure-string transforms plus board-aware UCI translation (look up piece on from-square): castling-zero, mixed-castling rejection, `P`-stripping, hyphen-stripping (LAN), UCI form translation, missing-`=` insertion, all four case fixups. LAN and UCI are mutually exclusive at the input level — a hyphen means LAN (`LONG_ALGEBRAIC_NOTATION` only), no hyphen means UCI shape (`UCI_NOTATION` only). *Phase 2 (semantic recovery)* feeds the normalized candidate to the strict pipeline and, on a recoverable rejection (terminal-marker mismatch, capture-marker mismatch, over-specification, non-standard disambig), mutates the candidate and retries. Each lenient code can fire at most once per parse, bounding the loop.
+
+**API.** `LenientSanParser.parseText(String, ChessBoard)` returns a `LenientSanParserValidationResult` (move + forgiven items). `LenientSanParser.validateText(String, ChessBoard)` is the same call with the result discarded — convenience for yes/no checks. `Board.performMoveLenient(String)` returns the same result type so the convenience path also surfaces forgiven items.
+
+**Deliberate non-recoveries.** Three categories are rejected even by the lenient pipeline:
+- **Mixed castling** (`0-O`, `O-0`) — no real-world tool emits this; allowing it would add parser complexity for zero practical value.
+- **Pawn `SPURIOUS_CAPTURE_MARKER`** — `dxe5` when e5 is empty has no clean string mutation that yields canonical SAN; the only "recovery" would silently swap the user's intended pawn (d-file) for a different one (e-file). That crosses the line from forgiving sloppiness to overriding intent.
+- **Game already terminated** — top-of-pipeline guard before the lenient layer engages, identical to strict; once a FIDE-automatic termination is reached no further moves are accepted, lenient or otherwise.
+
+The strict pipeline remains the single source of chess-validation truth. Lenient is a thin input-shape transformation layer that reuses strict for everything else.
 
 ---
 

--- a/src/main/java/com/dlb/chess/board/Board.java
+++ b/src/main/java/com/dlb/chess/board/Board.java
@@ -45,6 +45,8 @@ import com.dlb.chess.san.AbstractSan;
 import com.dlb.chess.san.MoveToLan;
 import com.dlb.chess.san.MoveToSan;
 import com.dlb.chess.san.enums.SanTerminalMarker;
+import com.dlb.chess.san.lenient.LenientSanParser;
+import com.dlb.chess.san.model.LenientSanParserValidationResult;
 import com.dlb.chess.san.validate.SanValidation;
 import com.dlb.chess.squares.to.attacked.AbstractAttackedSquares;
 import com.google.common.collect.ImmutableList;
@@ -247,6 +249,26 @@ public class Board implements ChessBoard {
   @Override
   public boolean performMove(String san) {
     return performMoves(san);
+  }
+
+  /**
+   * Plays the given move on this board, specified in lenient SAN. Accepts inputs the strict pipeline rejects when
+   * those inputs uniquely identify a legal move and the deviation matches a supported tolerance category (case
+   * variation, long-algebraic / UCI form, castling with digit zero, missing or wrong check / checkmate suffix,
+   * over-specification, missing or spurious capture marker, missing promotion equals, explicit pawn letter). The
+   * returned {@link LenientSanParserValidationResult} carries the resolved {@code MoveSpecification} together with
+   * one {@code ForgivenItem} per deviation that was forgiven; on canonical input the forgiven-items list is empty.
+   *
+   * @throws com.dlb.chess.san.exceptions.LenientSanParserValidationException if the input cannot be resolved to a
+   *         legal move even after applying every supported tolerance
+   */
+  public LenientSanParserValidationResult performMoveLenient(String san) {
+    if (san == null) {
+      throw new IllegalArgumentException("The SAN cannot be null");
+    }
+    final LenientSanParserValidationResult result = LenientSanParser.parseText(san, this);
+    this.performMoveWithoutValidation(result.moveSpecification());
+    return result;
   }
 
   /**

--- a/src/main/java/com/dlb/chess/board/Board.java
+++ b/src/main/java/com/dlb/chess/board/Board.java
@@ -76,8 +76,7 @@ import com.google.common.collect.ImmutableSet;
  * <p>
  * Move execution happens through {@link #moveStrict(String)}, {@link #moveLenient(String)},
  * {@link #move(MoveSpecification)}, {@link #movesStrict(String...)}, and is undone by {@link #unmove()}. Both
- * move-pipelines validate the
- * candidate against the current legal-move set; an invalid move throws (see
+ * move-pipelines validate the candidate against the current legal-move set; an invalid move throws (see
  * {@link com.dlb.chess.exceptions.InvalidMoveException} from the {@code MoveSpecification} pipeline,
  * {@code SanValidationException} from the SAN pipeline). Once the game has reached any FIDE-automatic termination
  * (checkmate, stalemate, mutual insufficient material, fivefold repetition, 75-move rule), neither pipeline accepts
@@ -250,29 +249,29 @@ public class Board implements ChessBoard {
    * answer. Use {@link #moveLenient(String)} when parsing real-world PGN that may contain forgivable deviations.
    *
    * @throws com.dlb.chess.san.exceptions.SanValidationException if {@code san} is not canonical SAN, or is canonical
-   *         but does not represent a legal move
+   *                                                             but does not represent a legal move
    */
   @Override
   public StrictSanParserValidationResult moveStrict(String san) {
     final StrictSanParserValidationResult result = StrictSanParser.parseText(san, this);
     this.performMoveWithoutValidation(result.moveSpecification());
     if (!san.equals(this.getSan())) {
-      throw new ProgrammingMistakeException(
-          "The provided SAN and generated SAN are different, this should not happen");
+      throw new ProgrammingMistakeException("The provided SAN and generated SAN are different, this should not happen");
     }
     return result;
   }
 
   /**
-   * Plays the given move on this board, specified in lenient SAN. Accepts inputs the strict pipeline rejects when
-   * those inputs uniquely identify a legal move and the deviation matches a supported tolerance category (case
-   * variation, long-algebraic / UCI form, castling with digit zero, missing or wrong check / checkmate suffix,
-   * over-specification, missing or spurious capture marker, missing promotion equals, explicit pawn letter). The
-   * returned {@link LenientSanParserValidationResult} carries the resolved {@code MoveSpecification} together with
-   * one {@code ForgivenItem} per deviation that was forgiven; on canonical input the forgiven-items list is empty.
+   * Plays the given move on this board, specified in lenient SAN. Accepts inputs the strict pipeline rejects when those
+   * inputs uniquely identify a legal move and the deviation matches a supported tolerance category (case variation,
+   * long-algebraic / UCI form, castling with digit zero, missing or wrong check / checkmate suffix, over-specification,
+   * missing or spurious capture marker, missing promotion equals, explicit pawn letter). The returned
+   * {@link LenientSanParserValidationResult} carries the resolved {@code MoveSpecification} together with one
+   * {@code ForgivenItem} per deviation that was forgiven; on canonical input the forgiven-items list is empty.
    *
-   * @throws com.dlb.chess.san.exceptions.LenientSanParserValidationException if the input cannot be resolved to a
-   *         legal move even after applying every supported tolerance
+   * @throws com.dlb.chess.san.exceptions.LenientSanParserValidationException if the input cannot be resolved to a legal
+   *                                                                          move even after applying every supported
+   *                                                                          tolerance
    */
   @Override
   public LenientSanParserValidationResult moveLenient(String san) {
@@ -282,8 +281,8 @@ public class Board implements ChessBoard {
   }
 
   /**
-   * Plays the given sequence of canonical SAN moves on this board, in order. Convenience for batch play; the
-   * absence of a thrown exception means every move was canonical and legal.
+   * Plays the given sequence of canonical SAN moves on this board, in order. Convenience for batch play; the absence of
+   * a thrown exception means every move was canonical and legal.
    */
   @Override
   public boolean movesStrict(String... sanArray) {
@@ -292,6 +291,21 @@ public class Board implements ChessBoard {
         throw new IllegalArgumentException("The SAN cannot be null");
       }
       moveStrict(san);
+    }
+    return true;
+  }
+
+  /**
+   * Plays the given sequence of canonical SAN moves on this board, in order. Convenience for batch play; the absence of
+   * a thrown exception means every move was canonical and legal.
+   */
+  @Override
+  public boolean movesLenient(String... sanArray) {
+    for (final String san : sanArray) {
+      if (san == null) {
+        throw new IllegalArgumentException("The SAN cannot be null");
+      }
+      moveLenient(san);
     }
     return true;
   }

--- a/src/main/java/com/dlb/chess/board/Board.java
+++ b/src/main/java/com/dlb/chess/board/Board.java
@@ -263,9 +263,6 @@ public class Board implements ChessBoard {
    *         legal move even after applying every supported tolerance
    */
   public LenientSanParserValidationResult performMoveLenient(String san) {
-    if (san == null) {
-      throw new IllegalArgumentException("The SAN cannot be null");
-    }
     final LenientSanParserValidationResult result = LenientSanParser.parseText(san, this);
     this.performMoveWithoutValidation(result.moveSpecification());
     return result;

--- a/src/main/java/com/dlb/chess/board/Board.java
+++ b/src/main/java/com/dlb/chess/board/Board.java
@@ -47,7 +47,8 @@ import com.dlb.chess.san.MoveToSan;
 import com.dlb.chess.san.enums.SanTerminalMarker;
 import com.dlb.chess.san.lenient.LenientSanParser;
 import com.dlb.chess.san.model.LenientSanParserValidationResult;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.model.StrictSanParserValidationResult;
+import com.dlb.chess.san.validate.StrictSanParser;
 import com.dlb.chess.squares.to.attacked.AbstractAttackedSquares;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -73,8 +74,9 @@ import com.google.common.collect.ImmutableSet;
  * <h2>Mutating the game</h2>
  *
  * <p>
- * Move execution happens through {@link #performMove(String)}, {@link #performMove(MoveSpecification)},
- * {@link #performMoves(String...)}, and is undone by {@link #unperformMove()}. Both move-pipelines validate the
+ * Move execution happens through {@link #moveStrict(String)}, {@link #moveLenient(String)},
+ * {@link #move(MoveSpecification)}, {@link #movesStrict(String...)}, and is undone by {@link #unmove()}. Both
+ * move-pipelines validate the
  * candidate against the current legal-move set; an invalid move throws (see
  * {@link com.dlb.chess.exceptions.InvalidMoveException} from the {@code MoveSpecification} pipeline,
  * {@code SanValidationException} from the SAN pipeline). Once the game has reached any FIDE-automatic termination
@@ -90,7 +92,7 @@ import com.google.common.collect.ImmutableSet;
  * {@link #isSeventyFiveMove()}, plus the unwinnability/dead-position pair from {@link ChessBoard}
  * ({@code isUnwinnableQuick}, {@code isUnwinnableFull}, {@code isDeadPositionQuick}, {@code isDeadPositionFull} — the
  * library's flagship CHA feature; see {@link com.dlb.chess.unwinnability}). Position-state accessors return Guava
- * {@code ImmutableList}/{@code ImmutableSet}; mutation is exclusively via {@code performMove}/{@code unperformMove}.
+ * {@code ImmutableList}/{@code ImmutableSet}; mutation is exclusively via {@code move}/{@code unmove}.
  *
  * <p>
  * For game-level reports (threefold-claim-ahead, repetition listings, no-progress sequences), use
@@ -237,18 +239,28 @@ public class Board implements ChessBoard {
    * an illegal move (or a move on a game already terminated) throws {@link InvalidMoveException}.
    */
   @Override
-  public boolean performMove(MoveSpecification moveSpecification) throws InvalidMoveException {
+  public boolean move(MoveSpecification moveSpecification) throws InvalidMoveException {
     ValidateNewMove.validateNewMove(this, moveSpecification);
     return performMoveWithoutValidation(moveSpecification);
   }
 
   /**
-   * Plays the given move on this board, specified in standard algebraic notation. SAN is validated against the current
-   * legal-move set and against the strict SAN format rules; an invalid SAN throws {@code SanValidationException}.
+   * Plays the given move on this board, specified in canonical SAN. The result carries the resolved
+   * {@link MoveSpecification}; for callers that only need success / fail, the absence of a thrown exception is the
+   * answer. Use {@link #moveLenient(String)} when parsing real-world PGN that may contain forgivable deviations.
+   *
+   * @throws com.dlb.chess.san.exceptions.SanValidationException if {@code san} is not canonical SAN, or is canonical
+   *         but does not represent a legal move
    */
   @Override
-  public boolean performMove(String san) {
-    return performMoves(san);
+  public StrictSanParserValidationResult moveStrict(String san) {
+    final StrictSanParserValidationResult result = StrictSanParser.parseText(san, this);
+    this.performMoveWithoutValidation(result.moveSpecification());
+    if (!san.equals(this.getSan())) {
+      throw new ProgrammingMistakeException(
+          "The provided SAN and generated SAN are different, this should not happen");
+    }
+    return result;
   }
 
   /**
@@ -262,27 +274,24 @@ public class Board implements ChessBoard {
    * @throws com.dlb.chess.san.exceptions.LenientSanParserValidationException if the input cannot be resolved to a
    *         legal move even after applying every supported tolerance
    */
-  public LenientSanParserValidationResult performMoveLenient(String san) {
+  @Override
+  public LenientSanParserValidationResult moveLenient(String san) {
     final LenientSanParserValidationResult result = LenientSanParser.parseText(san, this);
     this.performMoveWithoutValidation(result.moveSpecification());
     return result;
   }
 
   /**
-   * Plays the given sequence of SAN moves on this board, in order. Equivalent to repeated {@link #performMove(String)}.
+   * Plays the given sequence of canonical SAN moves on this board, in order. Convenience for batch play; the
+   * absence of a thrown exception means every move was canonical and legal.
    */
   @Override
-  public boolean performMoves(String... sanArray) {
+  public boolean movesStrict(String... sanArray) {
     for (final String san : sanArray) {
       if (san == null) {
         throw new IllegalArgumentException("The SAN cannot be null");
       }
-      final MoveSpecification moveSpecification = SanValidation.validateSan(san, this);
-      this.performMoveWithoutValidation(moveSpecification);
-      if (!san.equals(this.getSan())) {
-        throw new ProgrammingMistakeException(
-            "The provided SAN and generated SAN are different, this should not happen");
-      }
+      moveStrict(san);
     }
     return true;
   }
@@ -407,7 +416,7 @@ public class Board implements ChessBoard {
    * no move has been played from the initial FEN.
    */
   @Override
-  public void unperformMove() {
+  public void unmove() {
     if (isFirstMove()) {
       throw new ProgrammingMistakeException("Undo move requested but no move to undo");
     }
@@ -501,12 +510,12 @@ public class Board implements ChessBoard {
     for (final LegalMove legalMove : getLegalMoveSet()) {
       // we must not check moves creating a position that never occurred so far
       if (!BasicChessUtility.calculateIsResetHalfMoveClock(legalMove)) {
-        this.performMove(legalMove.moveSpecification());
+        this.move(legalMove.moveSpecification());
         if (isThreefoldRepetition()) {
-          this.unperformMove();
+          this.unmove();
           return true;
         }
-        this.unperformMove();
+        this.unmove();
       }
     }
     return false;

--- a/src/main/java/com/dlb/chess/board/Board.java
+++ b/src/main/java/com/dlb/chess/board/Board.java
@@ -16,11 +16,11 @@ import com.dlb.chess.board.enums.Piece;
 import com.dlb.chess.board.enums.Side;
 import com.dlb.chess.board.enums.Square;
 import com.dlb.chess.common.NonNullWrapperCommon;
-import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.common.constants.ChessConstants;
 import com.dlb.chess.common.constants.DynamicPositionConstants;
 import com.dlb.chess.common.enums.EnPassantCaptureRuleThreefold;
 import com.dlb.chess.common.exceptions.ProgrammingMistakeException;
+import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.common.model.DynamicPosition;
 import com.dlb.chess.common.model.HalfMove;
 import com.dlb.chess.common.model.MoveSpecification;
@@ -53,8 +53,8 @@ import com.google.common.collect.ImmutableSet;
 /**
  * The library's central type — a chess <em>game</em>, not merely a position. A {@code Board} carries the position
  * <strong>plus</strong> the move history from its initial FEN: every halfmove ever performed, the legal-move set after
- * each, the halfmove clock, repetition counts, castling-right loss reasons, derived SAN/LAN strings — everything
- * needed to answer rule-level questions about the game so far.
+ * each, the halfmove clock, repetition counts, castling-right loss reasons, derived SAN/LAN strings — everything needed
+ * to answer rule-level questions about the game so far.
  *
  * <h2>Construction</h2>
  *
@@ -98,9 +98,9 @@ import com.google.common.collect.ImmutableSet;
  *
  * <p>
  * {@code Board} is mutable and <strong>not thread-safe</strong>. Use one {@code Board} per thread, or synchronize
- * externally. {@link #equals(Object)} and {@link #hashCode()} reflect the current game state, so a {@code Board}
- * placed in a {@link java.util.HashMap} or {@link java.util.HashSet} and then mutated will violate the collection's
- * invariants — don't do that.
+ * externally. {@link #equals(Object)} and {@link #hashCode()} reflect the current game state, so a {@code Board} placed
+ * in a {@link java.util.HashMap} or {@link java.util.HashSet} and then mutated will violate the collection's invariants
+ * — don't do that.
  */
 public class Board implements ChessBoard {
 
@@ -121,7 +121,9 @@ public class Board implements ChessBoard {
   private final List<CastlingRightLoss> blackKingSideLossList;
   private final List<CastlingRightLoss> blackQueenSideLossList;
 
-  /** Constructs a {@code Board} at the position carried by the given pre-parsed {@link Fen}. */
+  /**
+   * Constructs a {@code Board} at the position carried by the given pre-parsed {@link Fen}.
+   */
   public Board(Fen initialFen) {
 
     // using the static fen in case saves a bit of memory
@@ -207,15 +209,17 @@ public class Board implements ChessBoard {
 
   }
 
-  /** Constructs a {@code Board} at the standard initial position. */
+  /**
+   * Constructs a {@code Board} at the standard initial position.
+   */
   public Board() {
     this(FenConstants.FEN_INITIAL);
   }
 
   /**
    * Constructs a {@code Board} from a FEN string, validated by the advanced FEN parser. Rejects positions no real game
-   * could reach (impossible double-checks, halfmove clock above the 75-move-rule threshold, castling rights inconsistent
-   * with rooks-and-king positions, etc.).
+   * could reach (impossible double-checks, halfmove clock above the 75-move-rule threshold, castling rights
+   * inconsistent with rooks-and-king positions, etc.).
    */
   public Board(String fen) {
     this(FenParserAdvanced.parseFenAdvanced(fen));
@@ -245,7 +249,9 @@ public class Board implements ChessBoard {
     return performMoves(san);
   }
 
-  /** Plays the given sequence of SAN moves on this board, in order. Equivalent to repeated {@link #performMove(String)}. */
+  /**
+   * Plays the given sequence of SAN moves on this board, in order. Equivalent to repeated {@link #performMove(String)}.
+   */
   @Override
   public boolean performMoves(String... sanArray) {
     for (final String san : sanArray) {

--- a/src/main/java/com/dlb/chess/board/package-info.java
+++ b/src/main/java/com/dlb/chess/board/package-info.java
@@ -10,7 +10,7 @@
  *
  * <ul>
  * <li>{@link com.dlb.chess.board.ValidateNewMove#validateNewMove} (MoveSpecification pipeline)</li>
- * <li>{@code com.dlb.chess.san.validate.SanValidation#validateSan} (SAN pipeline)</li>
+ * <li>{@code com.dlb.chess.san.validate.StrictSanParser#parseText} (SAN pipeline)</li>
  * </ul>
  *
  * <p>

--- a/src/main/java/com/dlb/chess/common/enums/GameStatus.java
+++ b/src/main/java/com/dlb/chess/common/enums/GameStatus.java
@@ -4,7 +4,7 @@ package com.dlb.chess.common.enums;
  * Status of a game (board with history). The five FIDE-automatic terminations ({@link #CHECKMATE}, {@link #STALEMATE},
  * {@link #INSUFFICIENT_MATERIAL_BOTH}, {@link #FIVE_FOLD_REPETITION_RULE}, {@link #SEVENTY_FIVE_MOVE_RULE}) end the
  * game permanently — no further moves are accepted by the validation pipeline (see {@code ValidateNewMove} and
- * {@code SanValidation}).
+ * {@code StrictSanParser}).
  *
  * <p>
  * The two single-side insufficient-material variants ({@link #INSUFFICIENT_MATERIAL_MADE_THE_MOVE_ONLY},

--- a/src/main/java/com/dlb/chess/common/interfaces/ChessBoard.java
+++ b/src/main/java/com/dlb/chess/common/interfaces/ChessBoard.java
@@ -30,13 +30,15 @@ import com.google.common.collect.ImmutableSet;
 
 public interface ChessBoard extends EnumConstants {
 
-  boolean performMove(MoveSpecification moveSpecification);
+  boolean move(MoveSpecification moveSpecification);
 
-  boolean performMove(String san);
+  com.dlb.chess.san.model.StrictSanParserValidationResult moveStrict(String san);
 
-  boolean performMoves(String... sanArray);
+  com.dlb.chess.san.model.LenientSanParserValidationResult moveLenient(String san);
 
-  void unperformMove();
+  boolean movesStrict(String... sanArray);
+
+  void unmove();
 
   boolean isCheck();
 
@@ -237,9 +239,9 @@ public interface ChessBoard extends EnumConstants {
   default ImmutableSet<String> getLegalMovesSan() {
     final Set<String> result = new TreeSet<>();
     for (final MoveSpecification moveSpecification : getPossibleMoveSpecificationSet()) {
-      this.performMove(moveSpecification);
+      this.move(moveSpecification);
       result.add(getSan());
-      this.unperformMove();
+      this.unmove();
     }
     return NonNullWrapperCommon.copyOfSet(result);
   }

--- a/src/main/java/com/dlb/chess/common/interfaces/ChessBoard.java
+++ b/src/main/java/com/dlb/chess/common/interfaces/ChessBoard.java
@@ -19,6 +19,8 @@ import com.dlb.chess.common.model.MoveSpecification;
 import com.dlb.chess.common.ucimove.utility.UciMoveUtility;
 import com.dlb.chess.fen.model.Fen;
 import com.dlb.chess.model.LegalMove;
+import com.dlb.chess.san.model.LenientSanParserValidationResult;
+import com.dlb.chess.san.model.StrictSanParserValidationResult;
 import com.dlb.chess.unwinnability.full.UnwinnableFullAnalyzer;
 import com.dlb.chess.unwinnability.full.enums.DeadPositionFull;
 import com.dlb.chess.unwinnability.full.enums.UnwinnableFull;
@@ -32,11 +34,13 @@ public interface ChessBoard extends EnumConstants {
 
   boolean move(MoveSpecification moveSpecification);
 
-  com.dlb.chess.san.model.StrictSanParserValidationResult moveStrict(String san);
+  StrictSanParserValidationResult moveStrict(String san);
 
-  com.dlb.chess.san.model.LenientSanParserValidationResult moveLenient(String san);
+  LenientSanParserValidationResult moveLenient(String san);
 
   boolean movesStrict(String... sanArray);
+
+  boolean movesLenient(String... sanArray);
 
   void unmove();
 
@@ -119,8 +123,8 @@ public interface ChessBoard extends EnumConstants {
 
   /**
    * Quick (microsecond-scale, structural) CHA-based check whether the current position is dead — unwinnable for both
-   * sides. Three-valued: {@code DEAD_POSITION}, {@code NON_DEAD_POSITION}, {@code POSSIBLY_NON_DEAD_POSITION} (the third
-   * is a deliberate honesty signal — the quick algorithm is sound but not complete).
+   * sides. Three-valued: {@code DEAD_POSITION}, {@code NON_DEAD_POSITION}, {@code POSSIBLY_NON_DEAD_POSITION} (the
+   * third is a deliberate honesty signal — the quick algorithm is sound but not complete).
    */
   default DeadPositionQuick isDeadPositionQuick() {
     final UnwinnableQuick unwinnableWhite = UnwinnableQuickAnalyzer.unwinnableQuick(this, Side.WHITE);

--- a/src/main/java/com/dlb/chess/common/ucimove/utility/UciMoveUtility.java
+++ b/src/main/java/com/dlb/chess/common/ucimove/utility/UciMoveUtility.java
@@ -64,9 +64,9 @@ public abstract class UciMoveUtility {
 
   public static String convertUciMoveToSan(ChessBoard board, UciMove uciMove) {
     final MoveSpecification moveSpecification = convertUciMoveToMoveSpecification(board, uciMove);
-    board.performMove(moveSpecification);
+    board.move(moveSpecification);
     final String san = board.getSan();
-    board.unperformMove();
+    board.unmove();
     return san;
   }
 

--- a/src/main/java/com/dlb/chess/common/utility/GeneralUtility.java
+++ b/src/main/java/com/dlb/chess/common/utility/GeneralUtility.java
@@ -52,7 +52,7 @@ public abstract class GeneralUtility {
 
     for (final PgnHalfMove halfMove : pgnFile.halfMoveList()) {
       final String san = halfMove.san();
-      board.performMove(san);
+      board.moveStrict(san);
     }
 
     return board;
@@ -70,7 +70,7 @@ public abstract class GeneralUtility {
     final var board = new Board();
 
     for (final HalfMove halfMove : halfMoveList) {
-      board.performMove(halfMove.moveSpecification());
+      board.move(halfMove.moveSpecification());
     }
 
     return board;

--- a/src/main/java/com/dlb/chess/common/utility/ThreefoldClaimAheadUtility.java
+++ b/src/main/java/com/dlb/chess/common/utility/ThreefoldClaimAheadUtility.java
@@ -20,13 +20,13 @@ public abstract class ThreefoldClaimAheadUtility {
 
     for (final LegalMove legalMove : legalMoveList) {
       final List<ClaimAhead> resultList = new ArrayList<>();
-      board.performMove(legalMove.moveSpecification());
+      board.move(legalMove.moveSpecification());
       for (final LegalMove legalMoveCheckAhead : board.getLegalMoveSet()) {
-        board.performMove(legalMoveCheckAhead.moveSpecification());
+        board.move(legalMoveCheckAhead.moveSpecification());
         if (board.isThreefoldRepetition()) {
           resultList.add(new ClaimAhead(legalMoveCheckAhead, board.getFullMoveNumber(), board.getSan()));
         }
-        board.unperformMove();
+        board.unmove();
       }
       if (!resultList.isEmpty()) {
         resultListList.add(resultList);

--- a/src/main/java/com/dlb/chess/model/package-info.java
+++ b/src/main/java/com/dlb/chess/model/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Cross-cutting model types — small immutable value objects (records) used across the rule pipelines:
+ * Cross-cutting model types — small immutable value objects (records) used across the rule pipelines.
  *
  * <ul>
  * <li>{@link com.dlb.chess.model.LegalMove} — a {@link com.dlb.chess.common.model.MoveSpecification} plus the moving

--- a/src/main/java/com/dlb/chess/pgn/diagnostic/GameContinuationScanner.java
+++ b/src/main/java/com/dlb/chess/pgn/diagnostic/GameContinuationScanner.java
@@ -19,7 +19,7 @@ import com.dlb.chess.report.model.NoProgressHalfMove;
  * FIDE rules. It operates on raw halfmove data and does not interact with the strict move-validation pipeline.
  *
  * <p>
- * The strict pipeline ({@code ValidateNewMove}, {@code SanValidation}) rejects further moves once a terminal status is
+ * The strict pipeline ({@code ValidateNewMove}, {@code StrictSanParser}) rejects further moves once a terminal status is
  * reached. As a result, a normally replayed {@code Board} will never carry halfmove data that satisfies these
  * predicates — they are only useful for offline scans of pre-existing halfmove sequences obtained outside the strict
  * pipeline.

--- a/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
@@ -33,9 +33,12 @@ import com.dlb.chess.pgn.parser.sequential.PgnToken;
 import com.dlb.chess.pgn.parser.sequential.PgnTokenType;
 import com.dlb.chess.pgn.parser.sequential.PgnTokenizer;
 import com.dlb.chess.san.enums.SanValidationProblem;
-import com.dlb.chess.san.exceptions.SanValidationException;
+import com.dlb.chess.san.exceptions.LenientSanParserValidationException;
+import com.dlb.chess.san.model.ForgivenItem;
+import com.dlb.chess.san.model.LenientSanParserValidationResult;
 import com.dlb.chess.utility.TagPlaceHolderUtility;
 import com.dlb.chess.utility.TagUtility;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Lenient PGN parser. Permissive inter-token rules: any whitespace separates tokens, move-number indicators are
@@ -45,10 +48,13 @@ import com.dlb.chess.utility.TagUtility;
 public final class LenientPgnParser {
 
   private static final int SAN_MIN_LENGTH = 2;
-  private static final int SAN_MAX_LENGTH = 7;
+  // Bumped from 7 to 9 to admit the longest lenient SAN forms — e.g. pawn LAN promotion with hyphen and check
+  // ("e7-e8=Q+" is 8 chars).
+  private static final int SAN_MAX_LENGTH = 9;
 
   private final String source;
   private final PgnTokenizer tokenizer;
+  private final List<ForgivenItem> sanForgivenItemsAccumulator = new ArrayList<>();
 
   private LenientPgnParser(String source) {
     this.source = NewlineNormalization.toLf(stripUtf8Bom(source));
@@ -97,37 +103,38 @@ public final class LenientPgnParser {
   }
 
   public static LenientPgnParserValidationResult validate(Path pgnFilePath) {
+    final LenientPgnParser parser;
     try {
-      parse(pgnFilePath);
-      return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.OK, SanValidationProblem.NONE,
-          "OK");
-    } catch (final LenientPgnParserValidationException e) {
-      @SuppressWarnings("null") @NonNull final String message = e.getMessage();
-      return new LenientPgnParserValidationResult(e.getLenientPgnParserValidationProblem(), e.getSanValidationProblem(),
-          message);
+      parser = new LenientPgnParser(FileUtility.readFileAsString(pgnFilePath));
     } catch (final RuntimeException e) {
-      final String message = unexpectedValidationErrorMessage(e);
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.UNKNOWN_ERROR,
-          SanValidationProblem.NONE, message);
+          SanValidationProblem.NONE, unexpectedValidationErrorMessage(e), null, ImmutableList.of());
     }
+    return runValidation(parser);
   }
 
   /**
-   * Like {@link #parseText(String)} but returns a structured result instead of throwing.
+   * Like {@link #parseText(String)} but returns a structured result instead of throwing. The result also carries the
+   * parsed {@link PgnFile} (on success) and the list of SAN-level deviations the lenient layer forgave during
+   * movetext replay.
    */
   public static LenientPgnParserValidationResult validateText(String pgn) {
+    return runValidation(new LenientPgnParser(pgn));
+  }
+
+  private static LenientPgnParserValidationResult runValidation(LenientPgnParser parser) {
     try {
-      parseText(pgn);
+      final PgnFile pgnFile = parser.parseInternal();
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.OK, SanValidationProblem.NONE,
-          "OK");
+          "OK", pgnFile, ImmutableList.copyOf(parser.sanForgivenItemsAccumulator));
     } catch (final LenientPgnParserValidationException e) {
       @SuppressWarnings("null") @NonNull final String message = e.getMessage();
-      return new LenientPgnParserValidationResult(e.getLenientPgnParserValidationProblem(), e.getSanValidationProblem(),
-          message);
+      return new LenientPgnParserValidationResult(e.getLenientPgnParserValidationProblem(),
+          e.getSanValidationProblem(), message, null, e.getSanForgivenItemsAccumulated());
     } catch (final RuntimeException e) {
       final String message = unexpectedValidationErrorMessage(e);
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.UNKNOWN_ERROR,
-          SanValidationProblem.NONE, message);
+          SanValidationProblem.NONE, message, null, ImmutableList.of());
     }
   }
 
@@ -171,7 +178,7 @@ public final class LenientPgnParser {
 
     final Fen startFen = calculateStartFen(tagList, isStartFromPosition);
 
-    validateBoardPerLastMove(startFen, movetext.halfMoveList());
+    final List<PgnHalfMove> canonicalHalfMoveList = replayBoardCanonicalizing(startFen, movetext.halfMoveList());
 
     fixTagListForMissingSevenTagRosterTags(tagList);
 
@@ -179,7 +186,7 @@ public final class LenientPgnParser {
     Collections.sort(tagList);
 
     return new PgnFile(NonNullWrapperCommon.copyOfList(tagList), startFen, movetext.pregameCommentary(),
-        NonNullWrapperCommon.copyOfList(movetext.halfMoveList()));
+        NonNullWrapperCommon.copyOfList(canonicalHalfMoveList));
   }
 
   // -------------------------------------------------------------------------------------------------
@@ -570,13 +577,23 @@ public final class LenientPgnParser {
   private static void validateSanCharacters(String san) {
     for (var i = 0; i < san.length(); i++) {
       final var c = san.charAt(i);
-      if (!com.dlb.chess.board.enums.Piece.exists(c) && !com.dlb.chess.board.enums.File.exists(c)
-          && !com.dlb.chess.board.enums.Rank.exists(c) && !com.dlb.chess.san.enums.SanSymbol.exists(c)) {
-        throw new LenientPgnParserValidationException(
-            LenientPgnParserValidationProblem.EXCEPTION_CAUGHT_FROM_STRICT_VALIDATION, SanValidationProblem.NONE,
-            "The movetext is invalid because a SAN contains an invalid character of \"" + c + "\".");
+      if (isAllowedLenientSanCharacter(c)) {
+        continue;
       }
+      throw new LenientPgnParserValidationException(
+          LenientPgnParserValidationProblem.EXCEPTION_CAUGHT_FROM_STRICT_VALIDATION, SanValidationProblem.NONE,
+          "The movetext is invalid because a SAN contains an invalid character of \"" + c + "\".");
     }
+  }
+
+  private static boolean isAllowedLenientSanCharacter(char c) {
+    if (com.dlb.chess.board.enums.Piece.exists(c) || com.dlb.chess.board.enums.File.exists(c)
+        || com.dlb.chess.board.enums.Rank.exists(c) || com.dlb.chess.san.enums.SanSymbol.exists(c)) {
+      return true;
+    }
+    // Lenient additions: uppercase file letter (UPPERCASE_FILE_LETTER), uppercase capture marker
+    // (UPPERCASE_CAPTURE_MARKER), digit zero (ZERO_INSTEAD_OF_O_CASTLING).
+    return c >= 'A' && c <= 'H' || c == 'X' || c == '0';
   }
 
   private static void validateSanLength(String san) {
@@ -661,26 +678,41 @@ public final class LenientPgnParser {
   // Board replay & post-processing
   // -------------------------------------------------------------------------------------------------
 
-  private static void validateBoardPerLastMove(Fen startFen, List<PgnHalfMove> halfMoveList) {
+  /**
+   * Replays each half-move on a fresh board via {@link Board#performMoveLenient}, accumulates SAN-level forgiven items
+   * into the parser-instance accumulator, and returns a copy of the half-move list with the canonical SAN substituted
+   * (so the resulting {@link PgnFile} compares equal to a strict-parsed file built from the same canonical moves).
+   * Move-suffix annotations and commentaries are carried through unchanged.
+   *
+   * <p>
+   * On a SAN-level failure the partial accumulator is included on the thrown
+   * {@link LenientPgnParserValidationException} so callers see how many deviations were forgiven before the failure.
+   * The {@link com.dlb.chess.common.enums.GameStatus} from a {@code GAME_ALREADY_ENDED} reject is propagated unchanged.
+   */
+  private List<PgnHalfMove> replayBoardCanonicalizing(Fen startFen, List<PgnHalfMove> halfMoveList) {
     final Board board = new Board(startFen);
+    final List<PgnHalfMove> canonicalList = new ArrayList<>(halfMoveList.size());
     for (final PgnHalfMove halfMove : halfMoveList) {
       final Side side = board.getHavingMove();
       final var fullMoveNumber = board.getFullMoveNumberForNextHalfMove();
       try {
-        board.performMove(halfMove.san());
-      } catch (final SanValidationException e) {
+        final LenientSanParserValidationResult result = board.performMoveLenient(halfMove.san());
+        sanForgivenItemsAccumulator.addAll(result.forgivenItems());
+        final String canonicalSan = board.getSan();
+        canonicalList.add(new PgnHalfMove(canonicalSan, halfMove.moveSuffixAnnotation(), halfMove.commentary()));
+      } catch (final LenientSanParserValidationException e) {
         final String moveNumberAndSan = HalfMoveUtility.calculateMoveNumberAndSanWithSpace(fullMoveNumber, side,
             halfMove.san());
         @SuppressWarnings("null") @NonNull final String messageSanValidationFailure = e.getMessage();
         final var message = "The validation for " + moveNumberAndSan + " failed. Reason: "
             + messageSanValidationFailure;
-        // Propagate the GameStatus from the SanValidationException for the GAME_ALREADY_ENDED
-        // case so callers can react to the specific termination cause without parsing the
-        // human-readable message. For any other SAN problem the GameStatus is null.
+        final SanValidationProblem underlying = e.getUnderlyingSanValidationProblem();
         throw new LenientPgnParserValidationException(LenientPgnParserValidationProblem.SAN,
-            e.getSanValidationProblem(), message, e.getGameStatus());
+            underlying == null ? SanValidationProblem.UNKNOWN_ERROR : underlying, message, e.getGameStatus(),
+            ImmutableList.copyOf(sanForgivenItemsAccumulator));
       }
     }
+    return canonicalList;
   }
 
   private static Fen calculateStartFen(List<Tag> tagList, boolean isStartFromPosition) {

--- a/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
@@ -53,7 +53,7 @@ public final class LenientPgnParser {
 
   private final String source;
   private final PgnTokenizer tokenizer;
-  private final List<ForgivenItem> sanForgivenItemsAccumulator = new ArrayList<>();
+  private final List<@NonNull ForgivenItem> sanForgivenItemsAccumulator = new ArrayList<>();
 
   private LenientPgnParser(String source) {
     this.source = NewlineNormalization.toLf(stripUtf8Bom(source));
@@ -108,7 +108,7 @@ public final class LenientPgnParser {
     } catch (final RuntimeException e) {
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.UNKNOWN_ERROR,
           SanValidationProblem.NONE, unexpectedValidationErrorMessage(e), null,
-          NonNullWrapperCommon.copyOfList(java.util.List.<ForgivenItem>of()));
+          ForgivenItem.EMPTY_LIST);
     }
     return runValidation(parser);
   }
@@ -134,7 +134,7 @@ public final class LenientPgnParser {
     } catch (final RuntimeException e) {
       final String message = unexpectedValidationErrorMessage(e);
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.UNKNOWN_ERROR,
-          SanValidationProblem.NONE, message, null, NonNullWrapperCommon.copyOfList(java.util.List.<ForgivenItem>of()));
+          SanValidationProblem.NONE, message, null, ForgivenItem.EMPTY_LIST);
     }
   }
 

--- a/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
@@ -108,7 +108,8 @@ public final class LenientPgnParser {
       parser = new LenientPgnParser(FileUtility.readFileAsString(pgnFilePath));
     } catch (final RuntimeException e) {
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.UNKNOWN_ERROR,
-          SanValidationProblem.NONE, unexpectedValidationErrorMessage(e), null, ImmutableList.of());
+          SanValidationProblem.NONE, unexpectedValidationErrorMessage(e), null,
+          NonNullWrapperCommon.copyOfList(java.util.List.<ForgivenItem>of()));
     }
     return runValidation(parser);
   }
@@ -126,7 +127,7 @@ public final class LenientPgnParser {
     try {
       final PgnFile pgnFile = parser.parseInternal();
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.OK, SanValidationProblem.NONE,
-          "OK", pgnFile, ImmutableList.copyOf(parser.sanForgivenItemsAccumulator));
+          "OK", pgnFile, NonNullWrapperCommon.copyOfList(parser.sanForgivenItemsAccumulator));
     } catch (final LenientPgnParserValidationException e) {
       @SuppressWarnings("null") @NonNull final String message = e.getMessage();
       return new LenientPgnParserValidationResult(e.getLenientPgnParserValidationProblem(),
@@ -134,7 +135,7 @@ public final class LenientPgnParser {
     } catch (final RuntimeException e) {
       final String message = unexpectedValidationErrorMessage(e);
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.UNKNOWN_ERROR,
-          SanValidationProblem.NONE, message, null, ImmutableList.of());
+          SanValidationProblem.NONE, message, null, NonNullWrapperCommon.copyOfList(java.util.List.<ForgivenItem>of()));
     }
   }
 
@@ -709,7 +710,7 @@ public final class LenientPgnParser {
         final SanValidationProblem underlying = e.getUnderlyingSanValidationProblem();
         throw new LenientPgnParserValidationException(LenientPgnParserValidationProblem.SAN,
             underlying == null ? SanValidationProblem.UNKNOWN_ERROR : underlying, message, e.getGameStatus(),
-            ImmutableList.copyOf(sanForgivenItemsAccumulator));
+            NonNullWrapperCommon.copyOfList(sanForgivenItemsAccumulator));
       }
     }
     return canonicalList;

--- a/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
@@ -38,7 +38,6 @@ import com.dlb.chess.san.model.ForgivenItem;
 import com.dlb.chess.san.model.LenientSanParserValidationResult;
 import com.dlb.chess.utility.TagPlaceHolderUtility;
 import com.dlb.chess.utility.TagUtility;
-import com.google.common.collect.ImmutableList;
 
 /**
  * Lenient PGN parser. Permissive inter-token rules: any whitespace separates tokens, move-number indicators are
@@ -116,8 +115,8 @@ public final class LenientPgnParser {
 
   /**
    * Like {@link #parseText(String)} but returns a structured result instead of throwing. The result also carries the
-   * parsed {@link PgnFile} (on success) and the list of SAN-level deviations the lenient layer forgave during
-   * movetext replay.
+   * parsed {@link PgnFile} (on success) and the list of SAN-level deviations the lenient layer forgave during movetext
+   * replay.
    */
   public static LenientPgnParserValidationResult validateText(String pgn) {
     return runValidation(new LenientPgnParser(pgn));
@@ -126,12 +125,12 @@ public final class LenientPgnParser {
   private static LenientPgnParserValidationResult runValidation(LenientPgnParser parser) {
     try {
       final PgnFile pgnFile = parser.parseInternal();
-      return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.OK, SanValidationProblem.NONE,
-          "OK", pgnFile, NonNullWrapperCommon.copyOfList(parser.sanForgivenItemsAccumulator));
+      return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.OK, SanValidationProblem.NONE, "OK",
+          pgnFile, NonNullWrapperCommon.copyOfList(parser.sanForgivenItemsAccumulator));
     } catch (final LenientPgnParserValidationException e) {
       @SuppressWarnings("null") @NonNull final String message = e.getMessage();
-      return new LenientPgnParserValidationResult(e.getLenientPgnParserValidationProblem(),
-          e.getSanValidationProblem(), message, null, e.getSanForgivenItemsAccumulated());
+      return new LenientPgnParserValidationResult(e.getLenientPgnParserValidationProblem(), e.getSanValidationProblem(),
+          message, null, e.getSanForgivenItemsAccumulated());
     } catch (final RuntimeException e) {
       final String message = unexpectedValidationErrorMessage(e);
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.UNKNOWN_ERROR,
@@ -142,7 +141,7 @@ public final class LenientPgnParser {
   @SuppressWarnings("null")
   private static @NonNull String unexpectedValidationErrorMessage(RuntimeException e) {
     final @Nullable String nullableReason = e.getMessage();
-    final String reason = nullableReason == null ? "" : nullableReason;
+    final var reason = nullableReason == null ? "" : nullableReason;
     return "An unexpected error occurred during validation. Reason: " + reason;
   }
 
@@ -680,9 +679,9 @@ public final class LenientPgnParser {
   // -------------------------------------------------------------------------------------------------
 
   /**
-   * Replays each half-move on a fresh board via {@link Board#moveLenient}, accumulates SAN-level forgiven items
-   * into the parser-instance accumulator, and returns a copy of the half-move list with the canonical SAN substituted
-   * (so the resulting {@link PgnFile} compares equal to a strict-parsed file built from the same canonical moves).
+   * Replays each half-move on a fresh board via {@link Board#moveLenient}, accumulates SAN-level forgiven items into
+   * the parser-instance accumulator, and returns a copy of the half-move list with the canonical SAN substituted (so
+   * the resulting {@link PgnFile} compares equal to a strict-parsed file built from the same canonical moves).
    * Move-suffix annotations and commentaries are carried through unchanged.
    *
    * <p>

--- a/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
@@ -53,7 +53,7 @@ public final class LenientPgnParser {
 
   private final String source;
   private final PgnTokenizer tokenizer;
-  private final List<@NonNull ForgivenItem> sanForgivenItemsAccumulator = new ArrayList<>();
+  private final List<ForgivenItem> sanForgivenItemsAccumulator = new ArrayList<>();
 
   private LenientPgnParser(String source) {
     this.source = NewlineNormalization.toLf(stripUtf8Bom(source));
@@ -107,8 +107,7 @@ public final class LenientPgnParser {
       parser = new LenientPgnParser(FileUtility.readFileAsString(pgnFilePath));
     } catch (final RuntimeException e) {
       return new LenientPgnParserValidationResult(LenientPgnParserValidationProblem.UNKNOWN_ERROR,
-          SanValidationProblem.NONE, unexpectedValidationErrorMessage(e), null,
-          ForgivenItem.EMPTY_LIST);
+          SanValidationProblem.NONE, unexpectedValidationErrorMessage(e), null, ForgivenItem.EMPTY_LIST);
     }
     return runValidation(parser);
   }

--- a/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/LenientPgnParser.java
@@ -680,7 +680,7 @@ public final class LenientPgnParser {
   // -------------------------------------------------------------------------------------------------
 
   /**
-   * Replays each half-move on a fresh board via {@link Board#performMoveLenient}, accumulates SAN-level forgiven items
+   * Replays each half-move on a fresh board via {@link Board#moveLenient}, accumulates SAN-level forgiven items
    * into the parser-instance accumulator, and returns a copy of the half-move list with the canonical SAN substituted
    * (so the resulting {@link PgnFile} compares equal to a strict-parsed file built from the same canonical moves).
    * Move-suffix annotations and commentaries are carried through unchanged.
@@ -697,7 +697,7 @@ public final class LenientPgnParser {
       final Side side = board.getHavingMove();
       final var fullMoveNumber = board.getFullMoveNumberForNextHalfMove();
       try {
-        final LenientSanParserValidationResult result = board.performMoveLenient(halfMove.san());
+        final LenientSanParserValidationResult result = board.moveLenient(halfMove.san());
         sanForgivenItemsAccumulator.addAll(result.forgivenItems());
         final String canonicalSan = board.getSan();
         canonicalList.add(new PgnHalfMove(canonicalSan, halfMove.moveSuffixAnnotation(), halfMove.commentary()));

--- a/src/main/java/com/dlb/chess/pgn/parser/StrictPgnParser.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/StrictPgnParser.java
@@ -647,7 +647,7 @@ public final class StrictPgnParser {
       final Side side = board.getHavingMove();
       final var fullMoveNumber = board.getFullMoveNumberForNextHalfMove();
       try {
-        board.performMove(halfMove.san());
+        board.moveStrict(halfMove.san());
       } catch (final SanValidationException e) {
         final String moveNumberAndSan = HalfMoveUtility.calculateMoveNumberAndSanWithSpace(fullMoveNumber, side,
             halfMove.san());

--- a/src/main/java/com/dlb/chess/pgn/parser/exceptions/LenientPgnParserValidationException.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/exceptions/LenientPgnParserValidationException.java
@@ -1,12 +1,17 @@
 package com.dlb.chess.pgn.parser.exceptions;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
+import com.dlb.chess.common.NonNullWrapperCommon;
 import com.dlb.chess.common.enums.GameStatus;
 import com.dlb.chess.common.exceptions.UsageException;
 import com.dlb.chess.pgn.parser.enums.LenientPgnParserValidationProblem;
 import com.dlb.chess.san.enums.SanValidationProblem;
+import com.dlb.chess.san.model.ForgivenItem;
+import com.google.common.collect.ImmutableList;
 
+@SuppressWarnings("null")
 public class LenientPgnParserValidationException extends UsageException {
 
   private final LenientPgnParserValidationProblem lenientPgnParserValidationProblem;
@@ -22,9 +27,16 @@ public class LenientPgnParserValidationException extends UsageException {
    */
   private final @Nullable GameStatus gameStatus;
 
+  /**
+   * SAN-level forgiven items accumulated during movetext replay before the failure point. Empty if the failure
+   * occurred outside the movetext path (tag validation, structural error) or if no SAN deviation had been forgiven
+   * yet.
+   */
+  private final @NonNull ImmutableList<@NonNull ForgivenItem> sanForgivenItemsAccumulated;
+
   public LenientPgnParserValidationException(LenientPgnParserValidationProblem lenientPgnParserValidationProblem,
       SanValidationProblem sanValidationProblem, String message) {
-    this(lenientPgnParserValidationProblem, sanValidationProblem, message, null);
+    this(lenientPgnParserValidationProblem, sanValidationProblem, message, null, ImmutableList.of());
   }
 
   /**
@@ -34,10 +46,21 @@ public class LenientPgnParserValidationException extends UsageException {
    */
   public LenientPgnParserValidationException(LenientPgnParserValidationProblem lenientPgnParserValidationProblem,
       SanValidationProblem sanValidationProblem, String message, @Nullable GameStatus gameStatus) {
+    this(lenientPgnParserValidationProblem, sanValidationProblem, message, gameStatus, ImmutableList.of());
+  }
+
+  /**
+   * Constructor used when the failure occurs during movetext replay and SAN-level forgiven items have already been
+   * accumulated for earlier moves. Carries those items so callers can see partial diagnostic data on failure.
+   */
+  public LenientPgnParserValidationException(LenientPgnParserValidationProblem lenientPgnParserValidationProblem,
+      SanValidationProblem sanValidationProblem, String message, @Nullable GameStatus gameStatus,
+      @NonNull ImmutableList<@NonNull ForgivenItem> sanForgivenItemsAccumulated) {
     super(message);
     this.lenientPgnParserValidationProblem = lenientPgnParserValidationProblem;
     this.sanValidationProblem = sanValidationProblem;
     this.gameStatus = gameStatus;
+    this.sanForgivenItemsAccumulated = NonNullWrapperCommon.copyOfList(sanForgivenItemsAccumulated);
   }
 
   public LenientPgnParserValidationProblem getLenientPgnParserValidationProblem() {
@@ -54,6 +77,10 @@ public class LenientPgnParserValidationException extends UsageException {
    */
   public @Nullable GameStatus getGameStatus() {
     return gameStatus;
+  }
+
+  public @NonNull ImmutableList<@NonNull ForgivenItem> getSanForgivenItemsAccumulated() {
+    return sanForgivenItemsAccumulated;
   }
 
 }

--- a/src/main/java/com/dlb/chess/pgn/parser/model/LenientPgnParserValidationResult.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/model/LenientPgnParserValidationResult.java
@@ -1,10 +1,29 @@
 package com.dlb.chess.pgn.parser.model;
 
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.dlb.chess.common.NonNullWrapperCommon;
 import com.dlb.chess.pgn.parser.enums.LenientPgnParserValidationProblem;
 import com.dlb.chess.san.enums.SanValidationProblem;
+import com.dlb.chess.san.model.ForgivenItem;
+import com.google.common.collect.ImmutableList;
 
-public record LenientPgnParserValidationResult(LenientPgnParserValidationProblem problemParser,
-    SanValidationProblem problemSan, String message) {
+/**
+ * Outcome of a lenient PGN parse-with-validation. On success, {@link #pgnFile} carries the parsed model and
+ * {@link #sanForgivenItems} lists every SAN deviation the lenient layer forgave during movetext replay (empty when the
+ * input was already canonical). On failure, {@link #pgnFile} is {@code null} and {@link #sanForgivenItems} contains
+ * whatever was accumulated up to the failure point.
+ */
+@SuppressWarnings("null")
+public record LenientPgnParserValidationResult(@NonNull LenientPgnParserValidationProblem problemParser,
+    @NonNull SanValidationProblem problemSan, @NonNull String message, @Nullable PgnFile pgnFile,
+    @NonNull ImmutableList<@NonNull ForgivenItem> sanForgivenItems) {
+
+  public LenientPgnParserValidationResult {
+    sanForgivenItems = NonNullWrapperCommon.copyOfList(sanForgivenItems);
+  }
+
   public boolean isValid() {
     return problemParser == LenientPgnParserValidationProblem.OK;
   }

--- a/src/main/java/com/dlb/chess/pgn/parser/sequential/PgnTokenizer.java
+++ b/src/main/java/com/dlb/chess/pgn/parser/sequential/PgnTokenizer.java
@@ -216,7 +216,13 @@ public final class PgnTokenizer {
       }
       text.append((char) stream.read());
     }
-    return new PgnToken(PgnTokenType.TERMINATION_MARKER, NonNullWrapperCommon.toString(text), line, column);
+    final String result = NonNullWrapperCommon.toString(text);
+    // Lenient castling with digit zero ("0-0", "0-0-0") matches the digits-and-hyphens shape but is a SAN move,
+    // not a termination marker. The lenient SAN layer translates these to "O-O" / "O-O-O".
+    if ("0-0".equals(result) || "0-0-0".equals(result)) {
+      return new PgnToken(PgnTokenType.SYMBOL, result, line, column);
+    }
+    return new PgnToken(PgnTokenType.TERMINATION_MARKER, result, line, column);
   }
 
   private PgnToken readSymbol(int line, int column) {

--- a/src/main/java/com/dlb/chess/report/Reporter.java
+++ b/src/main/java/com/dlb/chess/report/Reporter.java
@@ -29,8 +29,8 @@ import com.dlb.chess.report.print.RepetitionPrint;
 import com.dlb.chess.report.print.ThreefoldClaimAheadPrint;
 
 /**
- * Generates game-level reports — threefold-repetition listings (including missed-claim-ahead opportunities), no-progress
- * (50/75-move-rule) sequences, and a printable summary — from a {@link ChessBoard} or a parsed PGN.
+ * Generates game-level reports — threefold-repetition listings (including missed-claim-ahead opportunities),
+ * no-progress (50/75-move-rule) sequences, and a printable summary — from a {@link ChessBoard} or a parsed PGN.
  *
  * <p>
  * Two surfaces:
@@ -40,8 +40,7 @@ import com.dlb.chess.report.print.ThreefoldClaimAheadPrint;
  * analytical data — repetition lists, threefold-claim-ahead slots, no-progress sequences. Use this for programmatic
  * inspection.</li>
  * <li>{@code printReport(...)} emits a human-readable summary to {@code stdout} via
- * {@link com.dlb.chess.messages.Message}. Use this for the kind of CLI-style output shown in the README
- * examples.</li>
+ * {@link com.dlb.chess.messages.Message}. Use this for the kind of CLI-style output shown in the README examples.</li>
  * </ul>
  *
  * <p>
@@ -75,28 +74,34 @@ public final class Reporter {
     printList(calculateReportLines(board));
   }
 
-  /** Returns the same human-readable report as {@link #printReport(String)} but as a single string, lines joined by
-   *  {@code "\n"}. Use this when the consumer is not stdout — web responses, file writes, GUI displays, etc. */
+  /**
+   * Returns the same human-readable report as {@link #printReport(String)} but as a single string, lines joined by
+   * {@code "\n"}. Use this when the consumer is not stdout — web responses, file writes, GUI displays, etc.
+   */
   public static String calculateReportText(String pgnString) {
     final PgnFile pgnFile = LenientPgnParser.parseText(pgnString);
     final ChessBoard board = GeneralUtility.calculateBoard(pgnFile);
     return calculateReportText(board);
   }
 
-  /** Returns the same human-readable report as {@link #printReport(Path, String)} but as a single string, lines
-   *  joined by {@code "\n"}. */
+  /**
+   * Returns the same human-readable report as {@link #printReport(Path, String)} but as a single string, lines joined
+   * by {@code "\n"}.
+   */
   public static String calculateReportText(Path folderPath, String pgnFileName) {
     final ChessBoard board = GeneralUtility.calculateBoard(folderPath, pgnFileName);
     return calculateReportText(board);
   }
 
-  /** Returns the same human-readable report as {@link #printReport(ChessBoard)} but as a single string, lines joined
-   *  by {@code "\n"}. */
+  /**
+   * Returns the same human-readable report as {@link #printReport(ChessBoard)} but as a single string, lines joined by
+   * {@code "\n"}.
+   */
   public static String calculateReportText(ChessBoard board) {
-    return String.join("\n", calculateReportLines(board));
+    return NonNullWrapperCommon.join("\n", calculateReportLines(board));
   }
 
-  private static @NonNull List<String> calculateReportLines(ChessBoard board) {
+  private static List<String> calculateReportLines(ChessBoard board) {
     final @NonNull List<String> output = new ArrayList<>();
 
     // repetition
@@ -162,8 +167,8 @@ public final class Reporter {
     final List<List<HalfMove>> repetitionListListInitialEnPassantCapture = calculateRepetitionListListInitialEnPassantCapture(
         halfMoveList);
 
-    final List<List<NoProgressHalfMove>> noProgressMoveListList = NoProgressMoveUtility.calculateNoProgressMoveRule(board,
-        ChessConstants.FIFTY_MOVE_RULE_HALF_MOVE_CLOCK_THRESHOLD);
+    final List<List<NoProgressHalfMove>> noProgressMoveListList = NoProgressMoveUtility
+        .calculateNoProgressMoveRule(board, ChessConstants.FIFTY_MOVE_RULE_HALF_MOVE_CLOCK_THRESHOLD);
 
     final var hasThreefoldRepetition = !repetitionListList.isEmpty();
     final var hasThreefoldRepetitionInitialEnPassantCapture = !repetitionListListInitialEnPassantCapture.isEmpty();
@@ -186,9 +191,9 @@ public final class Reporter {
     }
 
     return new Report(havingMove, halfMoveList, repetitionListList, repetitionListListInitialEnPassantCapture,
-        noProgressMoveListList, hasThreefoldRepetition, hasThreefoldRepetitionInitialEnPassantCapture, hasFivefoldRepetition,
-        hasFiftyMoveRule, hasSeventyFiveMoveRule, firstCapture, hasCapture, maxNoProgressSequence, checkmateOrStalemate,
-        insufficientMaterial, fen, board);
+        noProgressMoveListList, hasThreefoldRepetition, hasThreefoldRepetitionInitialEnPassantCapture,
+        hasFivefoldRepetition, hasFiftyMoveRule, hasSeventyFiveMoveRule, firstCapture, hasCapture,
+        maxNoProgressSequence, checkmateOrStalemate, insufficientMaterial, fen, board);
   }
 
   public static boolean calculateIsHalfMoveTerminatesNoProgressSequence(HalfMove halfMove) {

--- a/src/main/java/com/dlb/chess/san/enums/LenientSanValidationProblem.java
+++ b/src/main/java/com/dlb/chess/san/enums/LenientSanValidationProblem.java
@@ -1,0 +1,56 @@
+package com.dlb.chess.san.enums;
+
+/**
+ * Typed diagnostic codes emitted by the lenient SAN parser when it accepts an input that the strict parser rejects.
+ *
+ * <p>
+ * Each code names a specific, individually-detectable deviation from canonical SAN. A single move can carry multiple
+ * forgiven items (e.g. {@code nbxd7+} when actually mate triggers {@link #LOWERCASE_PIECE_LETTER},
+ * {@link #OVERSPECIFIED_FILE_DISAMBIGUATION}, and {@link #WRONG_CHECK_SUFFIX_FOR_CHECKMATE} simultaneously). The lenient
+ * parser surfaces every applicable code; consumers decide whether to silently accept or warn.
+ *
+ * <p>
+ * Codes are grouped by category. The grouping has no runtime meaning — it is for human readability only.
+ */
+public enum LenientSanValidationProblem {
+
+  // --- Decorative suffix mismatches: trailing +/# does not match actual board state after the move ---
+  MISSING_CHECK_SUFFIX,
+  MISSING_CHECKMATE_SUFFIX,
+  SPURIOUS_CHECK_SUFFIX,
+  SPURIOUS_CHECKMATE_SUFFIX,
+  WRONG_CHECK_SUFFIX_FOR_CHECKMATE,
+  WRONG_CHECKMATE_SUFFIX_FOR_CHECK,
+
+  // --- Capture marker mismatches: 'x' present without capture, or absent when capture occurs ---
+  MISSING_CAPTURE_MARKER,
+  SPURIOUS_CAPTURE_MARKER,
+
+  // --- Over-specification: more disambiguation than chess rules require ---
+  OVERSPECIFIED_FILE_DISAMBIGUATION,
+  OVERSPECIFIED_RANK_DISAMBIGUATION,
+  OVERSPECIFIED_SQUARE_DISAMBIGUATION,
+
+  // --- Non-canonical disambiguation form: user picked rank disambig where canonical SAN prefers file disambig.
+  // Distinct from OVERSPECIFIED_RANK_DISAMBIGUATION (which means no disambig was needed at all). Here a disambig IS
+  // required, but the canonical form uses file rather than rank. ---
+  NON_STANDARD_RANK_DISAMBIGUATION,
+
+  // --- Notation form: alternative move syntaxes that uniquely identify the same legal move ---
+  LONG_ALGEBRAIC_NOTATION,
+  UCI_NOTATION,
+  ZERO_INSTEAD_OF_O_CASTLING,
+  EXPLICIT_PAWN_LETTER,
+
+  // --- Promotion form ---
+  MISSING_PROMOTION_EQUALS,
+
+  // --- Case variation: SAN's case conventions are asymmetric (pieces uppercase, files lowercase, capture-marker
+  // lowercase, promotion piece uppercase). These codes name each direction of deviation. Canonical-case interpretation
+  // always wins when ambiguous (e.g. "bxc6" stays a pawn capture even if a bishop on the b-file could also capture). ---
+  LOWERCASE_PIECE_LETTER,
+  UPPERCASE_FILE_LETTER,
+  UPPERCASE_CAPTURE_MARKER,
+  LOWERCASE_PROMOTION_PIECE;
+
+}

--- a/src/main/java/com/dlb/chess/san/exceptions/LenientSanParserValidationException.java
+++ b/src/main/java/com/dlb/chess/san/exceptions/LenientSanParserValidationException.java
@@ -4,6 +4,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.dlb.chess.common.NonNullWrapperCommon;
+import com.dlb.chess.common.enums.GameStatus;
 import com.dlb.chess.common.exceptions.UsageException;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.model.ForgivenItem;
@@ -20,14 +21,27 @@ public class LenientSanParserValidationException extends UsageException {
 
   private final String originalText;
   private final @Nullable SanValidationProblem underlyingSanValidationProblem;
+  private final @Nullable GameStatus gameStatus;
   private final @NonNull ImmutableList<@NonNull ForgivenItem> forgivenItemsAccumulated;
 
   public LenientSanParserValidationException(String message, String originalText,
       @Nullable SanValidationProblem underlyingSanValidationProblem,
       @NonNull ImmutableList<@NonNull ForgivenItem> forgivenItemsAccumulated) {
+    this(message, originalText, underlyingSanValidationProblem, null, forgivenItemsAccumulated);
+  }
+
+  /**
+   * Constructor used when the underlying strict failure carries a {@link GameStatus} (the {@code GAME_ALREADY_ENDED}
+   * case): propagate the status so callers — particularly the lenient PGN parser — can identify the specific
+   * FIDE-automatic termination without parsing the message.
+   */
+  public LenientSanParserValidationException(String message, String originalText,
+      @Nullable SanValidationProblem underlyingSanValidationProblem, @Nullable GameStatus gameStatus,
+      @NonNull ImmutableList<@NonNull ForgivenItem> forgivenItemsAccumulated) {
     super(message);
     this.originalText = originalText;
     this.underlyingSanValidationProblem = underlyingSanValidationProblem;
+    this.gameStatus = gameStatus;
     this.forgivenItemsAccumulated = NonNullWrapperCommon.copyOfList(forgivenItemsAccumulated);
   }
 
@@ -50,6 +64,14 @@ public class LenientSanParserValidationException extends UsageException {
    */
   public @NonNull ImmutableList<@NonNull ForgivenItem> getForgivenItemsAccumulated() {
     return forgivenItemsAccumulated;
+  }
+
+  /**
+   * The {@link GameStatus} that ended the game when the underlying strict failure was {@code GAME_ALREADY_ENDED};
+   * {@code null} otherwise.
+   */
+  public @Nullable GameStatus getGameStatus() {
+    return gameStatus;
   }
 
 }

--- a/src/main/java/com/dlb/chess/san/exceptions/LenientSanParserValidationException.java
+++ b/src/main/java/com/dlb/chess/san/exceptions/LenientSanParserValidationException.java
@@ -1,0 +1,55 @@
+package com.dlb.chess.san.exceptions;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.dlb.chess.common.NonNullWrapperCommon;
+import com.dlb.chess.common.exceptions.UsageException;
+import com.dlb.chess.san.enums.SanValidationProblem;
+import com.dlb.chess.san.model.ForgivenItem;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Thrown when the lenient SAN parser cannot resolve the input to a legal move even after applying every supported
+ * tolerance. Carries the original text, the deepest underlying strict-pipeline reason (when the failure originated
+ * there), and any forgiven items the lenient layer had already accumulated before the failure point — so the consumer
+ * can see how far the parse got.
+ */
+@SuppressWarnings("null")
+public class LenientSanParserValidationException extends UsageException {
+
+  private final String originalText;
+  private final @Nullable SanValidationProblem underlyingSanValidationProblem;
+  private final @NonNull ImmutableList<@NonNull ForgivenItem> forgivenItemsAccumulated;
+
+  public LenientSanParserValidationException(String message, String originalText,
+      @Nullable SanValidationProblem underlyingSanValidationProblem,
+      @NonNull ImmutableList<@NonNull ForgivenItem> forgivenItemsAccumulated) {
+    super(message);
+    this.originalText = originalText;
+    this.underlyingSanValidationProblem = underlyingSanValidationProblem;
+    this.forgivenItemsAccumulated = NonNullWrapperCommon.copyOfList(forgivenItemsAccumulated);
+  }
+
+  public String getOriginalText() {
+    return originalText;
+  }
+
+  /**
+   * The deepest underlying strict-pipeline rejection reason, when the lenient parser exhausted its recovery options and
+   * the final failure came from the strict layer; {@code null} if the lenient layer rejected the input on shape grounds
+   * before the strict layer was consulted (e.g. mixed {@code 0-O} castling).
+   */
+  public @Nullable SanValidationProblem getUnderlyingSanValidationProblem() {
+    return underlyingSanValidationProblem;
+  }
+
+  /**
+   * The forgiven items the lenient parser had already accumulated before failing. Useful for diagnostics — shows which
+   * tolerances applied before the input became unrecoverable.
+   */
+  public @NonNull ImmutableList<@NonNull ForgivenItem> getForgivenItemsAccumulated() {
+    return forgivenItemsAccumulated;
+  }
+
+}

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
@@ -19,7 +19,7 @@ import com.dlb.chess.san.exceptions.LenientSanParserValidationException;
 import com.dlb.chess.san.exceptions.SanValidationException;
 import com.dlb.chess.san.model.ForgivenItem;
 import com.dlb.chess.san.model.LenientSanParserValidationResult;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -51,7 +51,7 @@ public final class LenientSanParser {
   public static LenientSanParserValidationResult parseText(String text, ChessBoard board) {
     // Phase 0: try strict on the raw input first. Canonical SAN pays zero lenient overhead.
     try {
-      final MoveSpecification ms = SanValidation.validateSan(text, board);
+      final MoveSpecification ms = StrictSanParser.parseText(text, board).moveSpecification();
       return new LenientSanParserValidationResult(ms, NonNullWrapperCommon.copyOfList(List.<ForgivenItem>of()));
     } catch (SanValidationException ignored) {
       // Fall through to the lenient pipeline.
@@ -109,9 +109,9 @@ public final class LenientSanParser {
           "Resolved MoveSpecification not found in legal-move set; lenient parser invariant violated");
     }
 
-    board.performMove(moveSpecification);
+    board.move(moveSpecification);
     final SanTerminalMarker marker = AbstractSan.calculateSanTerminalMarker(board.isCheck(), board.isCheckmate());
-    board.unperformMove();
+    board.unmove();
 
     return MoveToSan.calculateSanLastMove(matching, legalMovesBefore, marker);
   }

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
@@ -3,6 +3,7 @@ package com.dlb.chess.san.lenient;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.dlb.chess.common.NonNullWrapperCommon;
@@ -52,7 +53,7 @@ public final class LenientSanParser {
     // Phase 0: try strict on the raw input first. Canonical SAN pays zero lenient overhead.
     try {
       final MoveSpecification ms = StrictSanParser.parseText(text, board).moveSpecification();
-      return new LenientSanParserValidationResult(ms, NonNullWrapperCommon.copyOfList(List.<ForgivenItem>of()));
+      return new LenientSanParserValidationResult(ms, ForgivenItem.EMPTY_LIST);
     } catch (@SuppressWarnings("unused") final SanValidationException ignored) {
       // Fall through to the lenient pipeline.
     }
@@ -68,14 +69,15 @@ public final class LenientSanParser {
     try {
       moveSpecification = LenientSanRecover.parseWithRecovery(normalized, board, codes);
     } catch (final SanValidationException finalReject) {
+      @SuppressWarnings("null") @NonNull final String reason = finalReject.getMessage();
       throw new LenientSanParserValidationException(
-          Message.getString("validation.san.lenient.parseFailed", text, finalReject.getMessage()), text,
+          Message.getString("validation.san.lenient.parseFailed", text, reason), text,
           finalReject.getSanValidationProblem(), finalReject.getGameStatus(), itemsWithoutCanonical(text, codes));
     }
 
     // Phase 3: compute the canonical-SAN equivalent and finalize the forgiven items.
     final String canonicalSan = computeCanonicalSan(moveSpecification, board);
-    final List<ForgivenItem> items = new ArrayList<>(codes.size());
+    final List<@NonNull ForgivenItem> items = new ArrayList<>(codes.size());
     for (final LenientSanValidationProblem code : codes) {
       items.add(new ForgivenItem(code, text, canonicalSan));
     }
@@ -119,12 +121,12 @@ public final class LenientSanParser {
   private static ImmutableList<ForgivenItem> itemsWithoutCanonical(String text,
       List<LenientSanValidationProblem> codes) {
     if (codes.isEmpty()) {
-      return NonNullWrapperCommon.copyOfList(List.<ForgivenItem>of());
+      return ForgivenItem.EMPTY_LIST;
     }
     // Failure path: the canonical SAN is unknown (the parse never resolved a move), so we surface the codes
     // accumulated so far paired with the original token. Callers diagnosing a failed lenient parse care about
     // which deviations applied before the failure, not the (unknown) canonical equivalent.
-    final List<ForgivenItem> items = new ArrayList<>(codes.size());
+    final List<@NonNull ForgivenItem> items = new ArrayList<>(codes.size());
     for (final LenientSanValidationProblem code : codes) {
       items.add(new ForgivenItem(code, text, text));
     }

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
@@ -77,7 +77,7 @@ public final class LenientSanParser {
 
     // Phase 3: compute the canonical-SAN equivalent and finalize the forgiven items.
     final String canonicalSan = computeCanonicalSan(moveSpecification, board);
-    final List<@NonNull ForgivenItem> items = new ArrayList<>(codes.size());
+    final List<ForgivenItem> items = new ArrayList<>(codes.size());
     for (final LenientSanValidationProblem code : codes) {
       items.add(new ForgivenItem(code, text, canonicalSan));
     }
@@ -126,7 +126,7 @@ public final class LenientSanParser {
     // Failure path: the canonical SAN is unknown (the parse never resolved a move), so we surface the codes
     // accumulated so far paired with the original token. Callers diagnosing a failed lenient parse care about
     // which deviations applied before the failure, not the (unknown) canonical equivalent.
-    final List<@NonNull ForgivenItem> items = new ArrayList<>(codes.size());
+    final List<ForgivenItem> items = new ArrayList<>(codes.size());
     for (final LenientSanValidationProblem code : codes) {
       items.add(new ForgivenItem(code, text, text));
     }

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
@@ -1,0 +1,130 @@
+package com.dlb.chess.san.lenient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.dlb.chess.common.exceptions.ProgrammingMistakeException;
+import com.dlb.chess.common.interfaces.ChessBoard;
+import com.dlb.chess.common.model.MoveSpecification;
+import com.dlb.chess.messages.Message;
+import com.dlb.chess.model.LegalMove;
+import com.dlb.chess.san.AbstractSan;
+import com.dlb.chess.san.MoveToSan;
+import com.dlb.chess.san.enums.LenientSanValidationProblem;
+import com.dlb.chess.san.enums.SanTerminalMarker;
+import com.dlb.chess.san.exceptions.LenientSanParserValidationException;
+import com.dlb.chess.san.exceptions.SanValidationException;
+import com.dlb.chess.san.model.ForgivenItem;
+import com.dlb.chess.san.model.LenientSanParserValidationResult;
+import com.dlb.chess.san.validate.SanValidation;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Public entry point for the lenient SAN pipeline. Accepts inputs that the strict pipeline rejects, when those inputs
+ * uniquely identify a legal move and the deviation matches a supported tolerance category.
+ *
+ * <p>
+ * See {@link com.dlb.chess.san.lenient package-level Javadoc} for the strategy. The two public methods are:
+ * <ul>
+ * <li>{@link #parseText(String, ChessBoard)} — full parse, returns the resolved move plus the list of forgiven items.
+ * <li>{@link #validateText(String, ChessBoard)} — discards the result, throws on rejection. Convenience for callers
+ * that only need yes/no.
+ * </ul>
+ */
+public final class LenientSanParser {
+
+  private LenientSanParser() {
+  }
+
+  /**
+   * Parses {@code text} as a SAN move on {@code board}, accepting a defined set of canonical-SAN deviations. On
+   * success, returns the resolved {@link MoveSpecification} together with one {@link ForgivenItem} per deviation that
+   * was forgiven. On a canonical input, the forgiven-items list is empty.
+   *
+   * @throws LenientSanParserValidationException if the input cannot be resolved to a legal move even after applying
+   *         every supported tolerance
+   */
+  public static LenientSanParserValidationResult parseText(String text, ChessBoard board) {
+    // Phase 0: try strict on the raw input first. Canonical SAN pays zero lenient overhead.
+    try {
+      final MoveSpecification ms = SanValidation.validateSan(text, board);
+      return new LenientSanParserValidationResult(ms, ImmutableList.of());
+    } catch (SanValidationException ignored) {
+      // Fall through to the lenient pipeline.
+    }
+
+    final List<LenientSanValidationProblem> codes = new ArrayList<>();
+
+    // Phase 1: shape normalization. Throws LenientSanParserValidationException for hard-rejected shapes
+    // (e.g. mixed 0-O castling).
+    final String normalized = LenientSanShapeNormalize.normalize(text, board, codes);
+
+    // Phase 2: try strict + recovery loop.
+    final MoveSpecification moveSpecification;
+    try {
+      moveSpecification = LenientSanRecover.parseWithRecovery(normalized, board, codes);
+    } catch (SanValidationException finalReject) {
+      throw new LenientSanParserValidationException(
+          Message.getString("validation.san.lenient.parseFailed", text, finalReject.getMessage()), text,
+          finalReject.getSanValidationProblem(), itemsWithoutCanonical(text, codes));
+    }
+
+    // Phase 3: compute the canonical-SAN equivalent and finalize the forgiven items.
+    final String canonicalSan = computeCanonicalSan(moveSpecification, board);
+    final ImmutableList.Builder<ForgivenItem> builder = ImmutableList.builder();
+    for (final LenientSanValidationProblem code : codes) {
+      builder.add(new ForgivenItem(code, text, canonicalSan));
+    }
+    return new LenientSanParserValidationResult(moveSpecification, builder.build());
+  }
+
+  /**
+   * Validates {@code text} as a lenient SAN move on {@code board}. Equivalent to {@link #parseText} with the result
+   * discarded.
+   *
+   * @throws LenientSanParserValidationException if the input cannot be resolved to a legal move even after applying
+   *         every supported tolerance
+   */
+  public static void validateText(String text, ChessBoard board) {
+    parseText(text, board);
+  }
+
+  // --- Helpers ---
+
+  private static String computeCanonicalSan(MoveSpecification moveSpecification, ChessBoard board) {
+    final ImmutableSet<LegalMove> legalMovesBefore = board.getLegalMoveSet();
+    LegalMove matching = null;
+    for (final LegalMove candidate : legalMovesBefore) {
+      if (candidate.moveSpecification().equals(moveSpecification)) {
+        matching = candidate;
+        break;
+      }
+    }
+    if (matching == null) {
+      throw new ProgrammingMistakeException(
+          "Resolved MoveSpecification not found in legal-move set; lenient parser invariant violated");
+    }
+
+    board.performMove(moveSpecification);
+    final SanTerminalMarker marker = AbstractSan.calculateSanTerminalMarker(board.isCheck(), board.isCheckmate());
+    board.unperformMove();
+
+    return MoveToSan.calculateSanLastMove(matching, legalMovesBefore, marker);
+  }
+
+  private static ImmutableList<ForgivenItem> itemsWithoutCanonical(String text,
+      List<LenientSanValidationProblem> codes) {
+    if (codes.isEmpty()) {
+      return ImmutableList.of();
+    }
+    // Failure path: the canonical SAN is unknown (the parse never resolved a move), so we surface the codes
+    // accumulated so far paired with the original token. Callers diagnosing a failed lenient parse care about
+    // which deviations applied before the failure, not the (unknown) canonical equivalent.
+    final ImmutableList.Builder<ForgivenItem> builder = ImmutableList.builder();
+    for (final LenientSanValidationProblem code : codes) {
+      builder.add(new ForgivenItem(code, text, text));
+    }
+    return builder.build();
+  }
+}

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
@@ -67,7 +67,7 @@ public final class LenientSanParser {
     } catch (SanValidationException finalReject) {
       throw new LenientSanParserValidationException(
           Message.getString("validation.san.lenient.parseFailed", text, finalReject.getMessage()), text,
-          finalReject.getSanValidationProblem(), itemsWithoutCanonical(text, codes));
+          finalReject.getSanValidationProblem(), finalReject.getGameStatus(), itemsWithoutCanonical(text, codes));
     }
 
     // Phase 3: compute the canonical-SAN equivalent and finalize the forgiven items.

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
@@ -46,14 +46,14 @@ public final class LenientSanParser {
    * was forgiven. On a canonical input, the forgiven-items list is empty.
    *
    * @throws LenientSanParserValidationException if the input cannot be resolved to a legal move even after applying
-   *         every supported tolerance
+   *                                             every supported tolerance
    */
   public static LenientSanParserValidationResult parseText(String text, ChessBoard board) {
     // Phase 0: try strict on the raw input first. Canonical SAN pays zero lenient overhead.
     try {
       final MoveSpecification ms = StrictSanParser.parseText(text, board).moveSpecification();
       return new LenientSanParserValidationResult(ms, NonNullWrapperCommon.copyOfList(List.<ForgivenItem>of()));
-    } catch (SanValidationException ignored) {
+    } catch (@SuppressWarnings("unused") final SanValidationException ignored) {
       // Fall through to the lenient pipeline.
     }
 
@@ -67,7 +67,7 @@ public final class LenientSanParser {
     final MoveSpecification moveSpecification;
     try {
       moveSpecification = LenientSanRecover.parseWithRecovery(normalized, board, codes);
-    } catch (SanValidationException finalReject) {
+    } catch (final SanValidationException finalReject) {
       throw new LenientSanParserValidationException(
           Message.getString("validation.san.lenient.parseFailed", text, finalReject.getMessage()), text,
           finalReject.getSanValidationProblem(), finalReject.getGameStatus(), itemsWithoutCanonical(text, codes));
@@ -87,7 +87,7 @@ public final class LenientSanParser {
    * discarded.
    *
    * @throws LenientSanParserValidationException if the input cannot be resolved to a legal move even after applying
-   *         every supported tolerance
+   *                                             every supported tolerance
    */
   public static void validateText(String text, ChessBoard board) {
     parseText(text, board);

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanParser.java
@@ -3,6 +3,9 @@ package com.dlb.chess.san.lenient;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.Nullable;
+
+import com.dlb.chess.common.NonNullWrapperCommon;
 import com.dlb.chess.common.exceptions.ProgrammingMistakeException;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.common.model.MoveSpecification;
@@ -49,7 +52,7 @@ public final class LenientSanParser {
     // Phase 0: try strict on the raw input first. Canonical SAN pays zero lenient overhead.
     try {
       final MoveSpecification ms = SanValidation.validateSan(text, board);
-      return new LenientSanParserValidationResult(ms, ImmutableList.of());
+      return new LenientSanParserValidationResult(ms, NonNullWrapperCommon.copyOfList(List.<ForgivenItem>of()));
     } catch (SanValidationException ignored) {
       // Fall through to the lenient pipeline.
     }
@@ -72,11 +75,11 @@ public final class LenientSanParser {
 
     // Phase 3: compute the canonical-SAN equivalent and finalize the forgiven items.
     final String canonicalSan = computeCanonicalSan(moveSpecification, board);
-    final ImmutableList.Builder<ForgivenItem> builder = ImmutableList.builder();
+    final List<ForgivenItem> items = new ArrayList<>(codes.size());
     for (final LenientSanValidationProblem code : codes) {
-      builder.add(new ForgivenItem(code, text, canonicalSan));
+      items.add(new ForgivenItem(code, text, canonicalSan));
     }
-    return new LenientSanParserValidationResult(moveSpecification, builder.build());
+    return new LenientSanParserValidationResult(moveSpecification, NonNullWrapperCommon.copyOfList(items));
   }
 
   /**
@@ -94,7 +97,7 @@ public final class LenientSanParser {
 
   private static String computeCanonicalSan(MoveSpecification moveSpecification, ChessBoard board) {
     final ImmutableSet<LegalMove> legalMovesBefore = board.getLegalMoveSet();
-    LegalMove matching = null;
+    @Nullable LegalMove matching = null;
     for (final LegalMove candidate : legalMovesBefore) {
       if (candidate.moveSpecification().equals(moveSpecification)) {
         matching = candidate;
@@ -116,15 +119,15 @@ public final class LenientSanParser {
   private static ImmutableList<ForgivenItem> itemsWithoutCanonical(String text,
       List<LenientSanValidationProblem> codes) {
     if (codes.isEmpty()) {
-      return ImmutableList.of();
+      return NonNullWrapperCommon.copyOfList(List.<ForgivenItem>of());
     }
     // Failure path: the canonical SAN is unknown (the parse never resolved a move), so we surface the codes
     // accumulated so far paired with the original token. Callers diagnosing a failed lenient parse care about
     // which deviations applied before the failure, not the (unknown) canonical equivalent.
-    final ImmutableList.Builder<ForgivenItem> builder = ImmutableList.builder();
+    final List<ForgivenItem> items = new ArrayList<>(codes.size());
     for (final LenientSanValidationProblem code : codes) {
-      builder.add(new ForgivenItem(code, text, text));
+      items.add(new ForgivenItem(code, text, text));
     }
-    return builder.build();
+    return NonNullWrapperCommon.copyOfList(items);
   }
 }

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanRecover.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanRecover.java
@@ -21,7 +21,7 @@ import com.dlb.chess.model.LegalMove;
 import com.dlb.chess.san.enums.LenientSanValidationProblem;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 /**
  * Phase 2 of the lenient pipeline: try the strict pipeline on the Phase 1 candidate; if strict rejects with one of the
@@ -48,7 +48,7 @@ final class LenientSanRecover {
     String current = candidate;
     for (var i = 0; i < MAX_ITERATIONS; i++) {
       try {
-        return SanValidation.validateSan(current, board);
+        return StrictSanParser.parseText(current, board).moveSpecification();
       } catch (SanValidationException e) {
         final SanValidationProblem strictCode = e.getSanValidationProblem();
         final @Nullable LenientSanValidationProblem lenientCode = mapToLenientCode(strictCode);

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanRecover.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanRecover.java
@@ -1,0 +1,239 @@
+package com.dlb.chess.san.lenient;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import com.dlb.chess.board.enums.File;
+import com.dlb.chess.board.enums.Piece;
+import com.dlb.chess.board.enums.PieceType;
+import com.dlb.chess.board.enums.Rank;
+import com.dlb.chess.board.enums.Side;
+import com.dlb.chess.board.enums.Square;
+import com.dlb.chess.common.enums.NotationMovingPiece;
+import com.dlb.chess.common.exceptions.ProgrammingMistakeException;
+import com.dlb.chess.common.interfaces.ChessBoard;
+import com.dlb.chess.common.model.MoveSpecification;
+import com.dlb.chess.model.LegalMove;
+import com.dlb.chess.san.enums.LenientSanValidationProblem;
+import com.dlb.chess.san.enums.SanValidationProblem;
+import com.dlb.chess.san.exceptions.SanValidationException;
+import com.dlb.chess.san.validate.SanValidation;
+
+/**
+ * Phase 2 of the lenient pipeline: try the strict pipeline on the Phase 1 candidate; if strict rejects with one of the
+ * recoverable diagnostic codes (over-specification, capture-marker mismatch, terminal-marker mismatch), mutate the
+ * candidate, accumulate a forgiven item, and retry. If strict rejects with a non-recoverable code, the original
+ * {@link SanValidationException} is propagated to the caller, which wraps it in a
+ * {@link com.dlb.chess.san.exceptions.LenientSanParserValidationException}.
+ *
+ * <p>
+ * The recovery loop is bounded by the number of distinct lenient codes (each can fire at most once per parse).
+ */
+final class LenientSanRecover {
+
+  private static final int MAX_ITERATIONS = 16;
+
+  private LenientSanRecover() {
+  }
+
+  static MoveSpecification parseWithRecovery(String candidate, ChessBoard board,
+      List<LenientSanValidationProblem> codes) {
+    final Set<LenientSanValidationProblem> emitted = EnumSet.noneOf(LenientSanValidationProblem.class);
+    emitted.addAll(codes);
+
+    String current = candidate;
+    for (var i = 0; i < MAX_ITERATIONS; i++) {
+      try {
+        return SanValidation.validateSan(current, board);
+      } catch (SanValidationException e) {
+        final SanValidationProblem strictCode = e.getSanValidationProblem();
+        final LenientSanValidationProblem lenientCode = mapToLenientCode(strictCode);
+        if (lenientCode == null) {
+          throw e;
+        }
+        if (emitted.contains(lenientCode)) {
+          // Same code would fire twice — defensive bail-out; shouldn't happen because each mutation
+          // strictly reduces the set of applicable strict codes.
+          throw e;
+        }
+        current = mutate(current, strictCode, board);
+        emitted.add(lenientCode);
+        codes.add(lenientCode);
+      }
+    }
+    throw new ProgrammingMistakeException("Lenient SAN recovery exceeded iteration bound for candidate: " + candidate);
+  }
+
+  private static LenientSanValidationProblem mapToLenientCode(SanValidationProblem strictCode) {
+    return switch (strictCode) {
+      // Terminal-marker mismatches
+      case NO_SYMBOL_BUT_CHECK -> LenientSanValidationProblem.MISSING_CHECK_SUFFIX;
+      case NO_SYMBOL_BUT_CHECKMATE -> LenientSanValidationProblem.MISSING_CHECKMATE_SUFFIX;
+      case CHECK_SYMBOL_BUT_NO_CHECK -> LenientSanValidationProblem.SPURIOUS_CHECK_SUFFIX;
+      case CHECKMATE_SYMBOL_BUT_NO_CHECK -> LenientSanValidationProblem.SPURIOUS_CHECKMATE_SUFFIX;
+      case CHECK_SYMBOL_BUT_CHECKMATE -> LenientSanValidationProblem.WRONG_CHECK_SUFFIX_FOR_CHECKMATE;
+      case CHECKMATE_SYMBOL_BUT_CHECK_ONLY -> LenientSanValidationProblem.WRONG_CHECKMATE_SUFFIX_FOR_CHECK;
+
+      // Capture-marker mismatches (piece moves only — pawn variants are not auto-recoverable)
+      case DESTINATION_RNBQK_EMPTY_CAPTURE_SYMBOL -> LenientSanValidationProblem.SPURIOUS_CAPTURE_MARKER;
+      case DESTINATION_RNBQK_OPPONENT_NON_KING_NO_CAPTURE_SYMBOL -> LenientSanValidationProblem.MISSING_CAPTURE_MARKER;
+
+      // Disambiguation overspec
+      case OVERSPECIFIED_RNBQ_FILE_ONLY_ONE_LEGAL_MOVE -> LenientSanValidationProblem.OVERSPECIFIED_FILE_DISAMBIGUATION;
+      case OVERSPECIFIED_RNBQ_RANK_ONLY_ONE_LEGAL_MOVE -> LenientSanValidationProblem.OVERSPECIFIED_RANK_DISAMBIGUATION;
+      case NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE -> LenientSanValidationProblem.NON_STANDARD_RANK_DISAMBIGUATION;
+      case OVERSPECIFIED_RNBQ_SQUARE_ONLY_ONE_LEGAL_MOVE,
+           OVERSPECIFIED_RNBQ_SQUARE_FILE_NOT_NECESSARY,
+           OVERSPECIFIED_RNBQ_SQUARE_RANK_NOT_NECESSARY -> LenientSanValidationProblem.OVERSPECIFIED_SQUARE_DISAMBIGUATION;
+
+      default -> null;
+    };
+  }
+
+  private static String mutate(String current, SanValidationProblem strictCode, ChessBoard board) {
+    return switch (strictCode) {
+      // Terminal markers operate on the trailing character only
+      case NO_SYMBOL_BUT_CHECK -> current + "+";
+      case NO_SYMBOL_BUT_CHECKMATE -> current + "#";
+      case CHECK_SYMBOL_BUT_NO_CHECK, CHECKMATE_SYMBOL_BUT_NO_CHECK -> stripTerminalMarker(current);
+      case CHECK_SYMBOL_BUT_CHECKMATE -> stripTerminalMarker(current) + "#";
+      case CHECKMATE_SYMBOL_BUT_CHECK_ONLY -> stripTerminalMarker(current) + "+";
+
+      // Capture marker mutations (piece moves)
+      case DESTINATION_RNBQK_EMPTY_CAPTURE_SYMBOL -> stripCaptureMarker(current);
+      case DESTINATION_RNBQK_OPPONENT_NON_KING_NO_CAPTURE_SYMBOL -> insertCaptureMarker(current);
+
+      // Disambiguation strips
+      case OVERSPECIFIED_RNBQ_FILE_ONLY_ONE_LEGAL_MOVE,
+           OVERSPECIFIED_RNBQ_RANK_ONLY_ONE_LEGAL_MOVE -> stripFirstDisambigChar(current);
+      case OVERSPECIFIED_RNBQ_SQUARE_ONLY_ONE_LEGAL_MOVE -> stripSquareDisambig(current);
+      case OVERSPECIFIED_RNBQ_SQUARE_FILE_NOT_NECESSARY -> stripFirstDisambigChar(current);
+      case OVERSPECIFIED_RNBQ_SQUARE_RANK_NOT_NECESSARY -> stripSecondDisambigChar(current);
+
+      // Non-canonical disambig form: user typed rank where canonical is file. Resolve via board lookup.
+      case NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE -> rewriteRankAsFile(current, board);
+
+      default -> throw new ProgrammingMistakeException("No mutation defined for strict code: " + strictCode);
+    };
+  }
+
+  // --- Mutation helpers ---
+
+  private static String stripTerminalMarker(String s) {
+    if (s.isEmpty()) {
+      return s;
+    }
+    final char last = s.charAt(s.length() - 1);
+    if (last == '+' || last == '#') {
+      return s.substring(0, s.length() - 1);
+    }
+    return s;
+  }
+
+  private static String stripCaptureMarker(String s) {
+    final int x = s.indexOf('x');
+    if (x < 0) {
+      throw new ProgrammingMistakeException("stripCaptureMarker called with no 'x' in input: " + s);
+    }
+    return s.substring(0, x) + s.substring(x + 1);
+  }
+
+  private static String insertCaptureMarker(String s) {
+    final String body;
+    final String marker;
+    if (!s.isEmpty() && (s.charAt(s.length() - 1) == '+' || s.charAt(s.length() - 1) == '#')) {
+      body = s.substring(0, s.length() - 1);
+      marker = String.valueOf(s.charAt(s.length() - 1));
+    } else {
+      body = s;
+      marker = "";
+    }
+    if (body.length() < 3) {
+      throw new ProgrammingMistakeException("insertCaptureMarker called with body too short: " + s);
+    }
+    // Insert 'x' immediately before the destination square (last 2 chars of body).
+    final int destStart = body.length() - 2;
+    return body.substring(0, destStart) + "x" + body.substring(destStart) + marker;
+  }
+
+  private static String stripFirstDisambigChar(String s) {
+    final BodyAndMarker split = splitMarker(s);
+    if (split.body().length() < 4) {
+      throw new ProgrammingMistakeException("stripFirstDisambigChar called with body too short: " + s);
+    }
+    // RNBQ form: position 0 = piece, position 1 = disambig char to strip.
+    return split.body().charAt(0) + split.body().substring(2) + split.marker();
+  }
+
+  private static String stripSecondDisambigChar(String s) {
+    final BodyAndMarker split = splitMarker(s);
+    if (split.body().length() < 5) {
+      throw new ProgrammingMistakeException("stripSecondDisambigChar called with body too short: " + s);
+    }
+    // Square disambig form: positions 1 and 2 are file+rank; strip position 2 (rank).
+    return split.body().charAt(0) + split.body().substring(1, 2) + split.body().substring(3) + split.marker();
+  }
+
+  private static String stripSquareDisambig(String s) {
+    final BodyAndMarker split = splitMarker(s);
+    if (split.body().length() < 5) {
+      throw new ProgrammingMistakeException("stripSquareDisambig called with body too short: " + s);
+    }
+    // Square disambig form: strip both file and rank at positions 1 and 2.
+    return split.body().charAt(0) + split.body().substring(3) + split.marker();
+  }
+
+  /**
+   * Rewrites a rank-disambiguated SAN move to its canonical file-disambiguated form. Used when strict rejects with
+   * {@link SanValidationProblem#NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE} — the move is uniquely identified by
+   * the user's rank disambig, but canonical SAN prefers file disambig when both forms work. We look up the from-file
+   * of the unique matching legal move and substitute it for the rank character.
+   */
+  private static String rewriteRankAsFile(String s, ChessBoard board) {
+    final BodyAndMarker split = splitMarker(s);
+    final String body = split.body();
+    if (body.length() < 4) {
+      throw new ProgrammingMistakeException("rewriteRankAsFile body too short: " + s);
+    }
+    final char pieceLetter = body.charAt(0);
+    final char rankDigit = body.charAt(1);
+    final PieceType pieceType = NotationMovingPiece.calculate(pieceLetter).getPieceType();
+    final Rank fromRank = Rank.calculateRank(rankDigit);
+    final Square toSquare = Square.calculate(File.calculateFile(body.charAt(body.length() - 2)),
+        Rank.calculateRank(body.charAt(body.length() - 1)));
+    final Side havingMove = board.getHavingMove();
+    final Piece movingPiece = PieceType.calculate(havingMove, pieceType);
+
+    LegalMove match = null;
+    for (final LegalMove lm : board.getLegalMoveSet()) {
+      if (lm.movingPiece() == movingPiece && lm.moveSpecification().fromSquare().getRank() == fromRank
+          && lm.moveSpecification().toSquare() == toSquare) {
+        if (match != null) {
+          throw new ProgrammingMistakeException(
+              "Multiple legal moves match rank-disambig recovery; strict invariant violated: " + s);
+        }
+        match = lm;
+      }
+    }
+    if (match == null) {
+      throw new ProgrammingMistakeException(
+          "No legal move matches rank-disambig recovery; strict invariant violated: " + s);
+    }
+    final File fromFile = match.moveSpecification().fromSquare().getFile();
+    return body.charAt(0) + String.valueOf(fromFile.getLetter()) + body.substring(2) + split.marker();
+  }
+
+  private static BodyAndMarker splitMarker(String s) {
+    if (!s.isEmpty()) {
+      final char last = s.charAt(s.length() - 1);
+      if (last == '+' || last == '#') {
+        return new BodyAndMarker(s.substring(0, s.length() - 1), String.valueOf(last));
+      }
+    }
+    return new BodyAndMarker(s, "");
+  }
+
+  private record BodyAndMarker(String body, String marker) {
+  }
+}

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanRecover.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanRecover.java
@@ -4,12 +4,15 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.Nullable;
+
 import com.dlb.chess.board.enums.File;
 import com.dlb.chess.board.enums.Piece;
 import com.dlb.chess.board.enums.PieceType;
 import com.dlb.chess.board.enums.Rank;
 import com.dlb.chess.board.enums.Side;
 import com.dlb.chess.board.enums.Square;
+import com.dlb.chess.common.NonNullWrapperCommon;
 import com.dlb.chess.common.enums.NotationMovingPiece;
 import com.dlb.chess.common.exceptions.ProgrammingMistakeException;
 import com.dlb.chess.common.interfaces.ChessBoard;
@@ -48,7 +51,7 @@ final class LenientSanRecover {
         return SanValidation.validateSan(current, board);
       } catch (SanValidationException e) {
         final SanValidationProblem strictCode = e.getSanValidationProblem();
-        final LenientSanValidationProblem lenientCode = mapToLenientCode(strictCode);
+        final @Nullable LenientSanValidationProblem lenientCode = mapToLenientCode(strictCode);
         if (lenientCode == null) {
           throw e;
         }
@@ -65,7 +68,7 @@ final class LenientSanRecover {
     throw new ProgrammingMistakeException("Lenient SAN recovery exceeded iteration bound for candidate: " + candidate);
   }
 
-  private static LenientSanValidationProblem mapToLenientCode(SanValidationProblem strictCode) {
+  private static @Nullable LenientSanValidationProblem mapToLenientCode(SanValidationProblem strictCode) {
     return switch (strictCode) {
       // Terminal-marker mismatches
       case NO_SYMBOL_BUT_CHECK -> LenientSanValidationProblem.MISSING_CHECK_SUFFIX;
@@ -126,7 +129,7 @@ final class LenientSanRecover {
     }
     final char last = s.charAt(s.length() - 1);
     if (last == '+' || last == '#') {
-      return s.substring(0, s.length() - 1);
+      return NonNullWrapperCommon.substring(s, 0, s.length() - 1);
     }
     return s;
   }
@@ -136,15 +139,15 @@ final class LenientSanRecover {
     if (x < 0) {
       throw new ProgrammingMistakeException("stripCaptureMarker called with no 'x' in input: " + s);
     }
-    return s.substring(0, x) + s.substring(x + 1);
+    return NonNullWrapperCommon.substring(s, 0, x) + NonNullWrapperCommon.substring(s, x + 1);
   }
 
   private static String insertCaptureMarker(String s) {
     final String body;
     final String marker;
     if (!s.isEmpty() && (s.charAt(s.length() - 1) == '+' || s.charAt(s.length() - 1) == '#')) {
-      body = s.substring(0, s.length() - 1);
-      marker = String.valueOf(s.charAt(s.length() - 1));
+      body = NonNullWrapperCommon.substring(s, 0, s.length() - 1);
+      marker = NonNullWrapperCommon.valueOf(s.charAt(s.length() - 1));
     } else {
       body = s;
       marker = "";
@@ -154,7 +157,8 @@ final class LenientSanRecover {
     }
     // Insert 'x' immediately before the destination square (last 2 chars of body).
     final int destStart = body.length() - 2;
-    return body.substring(0, destStart) + "x" + body.substring(destStart) + marker;
+    return NonNullWrapperCommon.substring(body, 0, destStart) + "x" + NonNullWrapperCommon.substring(body, destStart)
+        + marker;
   }
 
   private static String stripFirstDisambigChar(String s) {
@@ -163,7 +167,7 @@ final class LenientSanRecover {
       throw new ProgrammingMistakeException("stripFirstDisambigChar called with body too short: " + s);
     }
     // RNBQ form: position 0 = piece, position 1 = disambig char to strip.
-    return split.body().charAt(0) + split.body().substring(2) + split.marker();
+    return split.body().charAt(0) + NonNullWrapperCommon.substring(split.body(), 2) + split.marker();
   }
 
   private static String stripSecondDisambigChar(String s) {
@@ -172,7 +176,8 @@ final class LenientSanRecover {
       throw new ProgrammingMistakeException("stripSecondDisambigChar called with body too short: " + s);
     }
     // Square disambig form: positions 1 and 2 are file+rank; strip position 2 (rank).
-    return split.body().charAt(0) + split.body().substring(1, 2) + split.body().substring(3) + split.marker();
+    return split.body().charAt(0) + NonNullWrapperCommon.substring(split.body(), 1, 2)
+        + NonNullWrapperCommon.substring(split.body(), 3) + split.marker();
   }
 
   private static String stripSquareDisambig(String s) {
@@ -181,7 +186,7 @@ final class LenientSanRecover {
       throw new ProgrammingMistakeException("stripSquareDisambig called with body too short: " + s);
     }
     // Square disambig form: strip both file and rank at positions 1 and 2.
-    return split.body().charAt(0) + split.body().substring(3) + split.marker();
+    return split.body().charAt(0) + NonNullWrapperCommon.substring(split.body(), 3) + split.marker();
   }
 
   /**
@@ -205,7 +210,7 @@ final class LenientSanRecover {
     final Side havingMove = board.getHavingMove();
     final Piece movingPiece = PieceType.calculate(havingMove, pieceType);
 
-    LegalMove match = null;
+    @Nullable LegalMove match = null;
     for (final LegalMove lm : board.getLegalMoveSet()) {
       if (lm.movingPiece() == movingPiece && lm.moveSpecification().fromSquare().getRank() == fromRank
           && lm.moveSpecification().toSquare() == toSquare) {
@@ -221,14 +226,16 @@ final class LenientSanRecover {
           "No legal move matches rank-disambig recovery; strict invariant violated: " + s);
     }
     final File fromFile = match.moveSpecification().fromSquare().getFile();
-    return body.charAt(0) + String.valueOf(fromFile.getLetter()) + body.substring(2) + split.marker();
+    return body.charAt(0) + NonNullWrapperCommon.valueOf(fromFile.getLetter())
+        + NonNullWrapperCommon.substring(body, 2) + split.marker();
   }
 
   private static BodyAndMarker splitMarker(String s) {
     if (!s.isEmpty()) {
       final char last = s.charAt(s.length() - 1);
       if (last == '+' || last == '#') {
-        return new BodyAndMarker(s.substring(0, s.length() - 1), String.valueOf(last));
+        return new BodyAndMarker(NonNullWrapperCommon.substring(s, 0, s.length() - 1),
+            NonNullWrapperCommon.valueOf(last));
       }
     }
     return new BodyAndMarker(s, "");

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
@@ -2,6 +2,8 @@ package com.dlb.chess.san.lenient;
 
 import java.util.List;
 
+import org.eclipse.jdt.annotation.Nullable;
+
 import com.dlb.chess.board.StaticPosition;
 import com.dlb.chess.board.enums.Piece;
 import com.dlb.chess.board.enums.PieceType;
@@ -12,7 +14,7 @@ import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.messages.Message;
 import com.dlb.chess.san.enums.LenientSanValidationProblem;
 import com.dlb.chess.san.exceptions.LenientSanParserValidationException;
-import com.google.common.collect.ImmutableList;
+import com.dlb.chess.san.model.ForgivenItem;
 
 /**
  * Phase 1 of the lenient pipeline: pure-string shape normalization plus board-aware UCI translation. Takes the raw user
@@ -41,15 +43,15 @@ final class LenientSanShapeNormalize {
       return text;
     }
 
-    final String castlingNormalized = tryNormalizeCastling(text, board, codes);
+    final @Nullable String castlingNormalized = tryNormalizeCastling(text, board, codes);
     if (castlingNormalized != null) {
       return castlingNormalized;
     }
 
     final char lastChar = text.charAt(text.length() - 1);
     final boolean hasTerminalMarker = lastChar == '+' || lastChar == '#';
-    final String terminalMarker = hasTerminalMarker ? String.valueOf(lastChar) : "";
-    String body = hasTerminalMarker ? text.substring(0, text.length() - 1) : text;
+    final String terminalMarker = hasTerminalMarker ? NonNullWrapperCommon.valueOf(lastChar) : "";
+    String body = hasTerminalMarker ? NonNullWrapperCommon.substring(text, 0, text.length() - 1) : text;
 
     body = stripExplicitPawnLetter(body, codes);
     body = handleLanOrUci(body, board, codes);
@@ -61,11 +63,12 @@ final class LenientSanShapeNormalize {
 
   // --- Castling normalization (returns null if the input doesn't match a castling shape) ---
 
-  private static String tryNormalizeCastling(String text, ChessBoard board, List<LenientSanValidationProblem> codes) {
+  private static @Nullable String tryNormalizeCastling(String text, ChessBoard board,
+      List<LenientSanValidationProblem> codes) {
     final char lastChar = text.charAt(text.length() - 1);
     final boolean hasTerminalMarker = lastChar == '+' || lastChar == '#';
-    final String marker = hasTerminalMarker ? String.valueOf(lastChar) : "";
-    final String body = hasTerminalMarker ? text.substring(0, text.length() - 1) : text;
+    final String marker = hasTerminalMarker ? NonNullWrapperCommon.valueOf(lastChar) : "";
+    final String body = hasTerminalMarker ? NonNullWrapperCommon.substring(text, 0, text.length() - 1) : text;
 
     // Classic O-O / 0-0 / mixed forms. Three or five characters with hyphens and zero-or-O at every other position.
     if (matchesCastlingZeroOPattern(body)) {
@@ -73,18 +76,19 @@ final class LenientSanShapeNormalize {
       final boolean hasZero = body.indexOf('0') >= 0;
       if (hasO && hasZero) {
         throw new LenientSanParserValidationException(
-            Message.getString("validation.san.lenient.mixedCastlingZeroAndO", text), text, null, ImmutableList.of());
+            Message.getString("validation.san.lenient.mixedCastlingZeroAndO", text), text, null,
+            NonNullWrapperCommon.copyOfList(List.<ForgivenItem>of()));
       }
       if (hasZero) {
         codes.add(LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING);
-        return body.replace('0', 'O') + marker;
+        return NonNullWrapperCommon.replace(body, '0', 'O') + marker;
       }
       // All-O: already canonical (or canonical with marker) — let strict handle it.
       return text;
     }
 
     // UCI king-castling: e1g1 / e1c1 / e8g8 / e8c8 with the king actually on the e-file home square.
-    final String uciCastling = tryTranslateUciCastling(body, board);
+    final @Nullable String uciCastling = tryTranslateUciCastling(body, board);
     if (uciCastling != null) {
       codes.add(LenientSanValidationProblem.UCI_NOTATION);
       return uciCastling + marker;
@@ -108,7 +112,7 @@ final class LenientSanShapeNormalize {
     return c == '0' || c == 'O';
   }
 
-  private static String tryTranslateUciCastling(String body, ChessBoard board) {
+  private static @Nullable String tryTranslateUciCastling(String body, ChessBoard board) {
     if (body.length() != 4) {
       return null;
     }
@@ -150,12 +154,12 @@ final class LenientSanShapeNormalize {
 
   private static String handleLanOrUci(String body, ChessBoard board, List<LenientSanValidationProblem> codes) {
     if (body.indexOf('-') >= 0) {
-      final String dehyphenated = body.replace("-", "");
+      final String dehyphenated = NonNullWrapperCommon.replace(body, "-", "");
       codes.add(LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION);
-      final String translated = tryTranslateUciShape(dehyphenated, board);
+      final @Nullable String translated = tryTranslateUciShape(dehyphenated, board);
       return translated != null ? translated : dehyphenated;
     }
-    final String translated = tryTranslateUciShape(body, board);
+    final @Nullable String translated = tryTranslateUciShape(body, board);
     if (translated != null) {
       codes.add(LenientSanValidationProblem.UCI_NOTATION);
       return translated;
@@ -168,7 +172,7 @@ final class LenientSanShapeNormalize {
    * SAN using the piece on the from-square. Returns {@code null} when the shape doesn't match — the caller decides
    * whether that means "leave the body unchanged" or "this branch doesn't apply."
    */
-  private static String tryTranslateUciShape(String body, ChessBoard board) {
+  private static @Nullable String tryTranslateUciShape(String body, ChessBoard board) {
     if (body.length() != 4 && body.length() != 5) {
       return null;
     }
@@ -239,7 +243,7 @@ final class LenientSanShapeNormalize {
     if (prev != '1' && prev != '8') {
       return body;
     }
-    if (len >= 3 && body.charAt(len - 3) == '=') {
+    if (body.charAt(len - 3) == '=') {
       return body;
     }
     codes.add(LenientSanValidationProblem.MISSING_PROMOTION_EQUALS);
@@ -260,7 +264,7 @@ final class LenientSanShapeNormalize {
       return body;
     }
     codes.add(LenientSanValidationProblem.UPPERCASE_CAPTURE_MARKER);
-    return body.replace('X', 'x');
+    return NonNullWrapperCommon.replace(body, 'X', 'x');
   }
 
   private static String caseFixLowercasePromotionPiece(String body, List<LenientSanValidationProblem> codes) {
@@ -339,7 +343,7 @@ final class LenientSanShapeNormalize {
 
   private static Square parseSquare(char fileLetter, char rankDigit) {
     try {
-      return Square.valueOf(("" + fileLetter + rankDigit).toUpperCase(java.util.Locale.ROOT));
+      return Square.valueOf(NonNullWrapperCommon.toUpperCase("" + fileLetter + rankDigit));
     } catch (IllegalArgumentException e) {
       throw new ProgrammingMistakeException("Square.valueOf failed for validated file/rank chars", e);
     }

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
@@ -1,0 +1,347 @@
+package com.dlb.chess.san.lenient;
+
+import java.util.List;
+
+import com.dlb.chess.board.StaticPosition;
+import com.dlb.chess.board.enums.Piece;
+import com.dlb.chess.board.enums.PieceType;
+import com.dlb.chess.board.enums.Square;
+import com.dlb.chess.common.NonNullWrapperCommon;
+import com.dlb.chess.common.exceptions.ProgrammingMistakeException;
+import com.dlb.chess.common.interfaces.ChessBoard;
+import com.dlb.chess.messages.Message;
+import com.dlb.chess.san.enums.LenientSanValidationProblem;
+import com.dlb.chess.san.exceptions.LenientSanParserValidationException;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Phase 1 of the lenient pipeline: pure-string shape normalization plus board-aware UCI translation. Takes the raw user
+ * input and produces a candidate SAN string in (or close to) canonical form, accumulating one
+ * {@link LenientSanValidationProblem} per detected deviation. The candidate is then handed to Phase 2
+ * ({@link LenientSanRecover}) for board-aware semantic recovery.
+ *
+ * <p>
+ * Order of normalization is significant — earlier steps assume later steps have not yet run. The order is:
+ * <ol>
+ * <li>Castling shape (zero-vs-O, mixed-rejection, UCI castling)
+ * <li>Strip terminal marker for body-only processing, re-attach at the end
+ * <li>UCI piece-move translation (board-aware lookup of the piece on the from-square)
+ * <li>Body transforms: explicit-P strip, LAN hyphen strip, missing promotion-equals insert
+ * <li>Case fixups (lowercase piece letter, uppercase file letter, uppercase capture marker, lowercase promotion piece)
+ * </ol>
+ */
+final class LenientSanShapeNormalize {
+
+  private LenientSanShapeNormalize() {
+  }
+
+  static String normalize(String text, ChessBoard board, List<LenientSanValidationProblem> codes) {
+    if (text.isBlank()) {
+      // Defer to strict for the canonical "blank" diagnostic.
+      return text;
+    }
+
+    final String castlingNormalized = tryNormalizeCastling(text, board, codes);
+    if (castlingNormalized != null) {
+      return castlingNormalized;
+    }
+
+    final char lastChar = text.charAt(text.length() - 1);
+    final boolean hasTerminalMarker = lastChar == '+' || lastChar == '#';
+    final String terminalMarker = hasTerminalMarker ? String.valueOf(lastChar) : "";
+    String body = hasTerminalMarker ? text.substring(0, text.length() - 1) : text;
+
+    body = stripExplicitPawnLetter(body, codes);
+    body = handleLanOrUci(body, board, codes);
+    body = insertMissingPromotionEquals(body, codes);
+    body = applyCaseFixups(body, codes);
+
+    return body + terminalMarker;
+  }
+
+  // --- Castling normalization (returns null if the input doesn't match a castling shape) ---
+
+  private static String tryNormalizeCastling(String text, ChessBoard board, List<LenientSanValidationProblem> codes) {
+    final char lastChar = text.charAt(text.length() - 1);
+    final boolean hasTerminalMarker = lastChar == '+' || lastChar == '#';
+    final String marker = hasTerminalMarker ? String.valueOf(lastChar) : "";
+    final String body = hasTerminalMarker ? text.substring(0, text.length() - 1) : text;
+
+    // Classic O-O / 0-0 / mixed forms. Three or five characters with hyphens and zero-or-O at every other position.
+    if (matchesCastlingZeroOPattern(body)) {
+      final boolean hasO = body.indexOf('O') >= 0;
+      final boolean hasZero = body.indexOf('0') >= 0;
+      if (hasO && hasZero) {
+        throw new LenientSanParserValidationException(
+            Message.getString("validation.san.lenient.mixedCastlingZeroAndO", text), text, null, ImmutableList.of());
+      }
+      if (hasZero) {
+        codes.add(LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING);
+        return body.replace('0', 'O') + marker;
+      }
+      // All-O: already canonical (or canonical with marker) — let strict handle it.
+      return text;
+    }
+
+    // UCI king-castling: e1g1 / e1c1 / e8g8 / e8c8 with the king actually on the e-file home square.
+    final String uciCastling = tryTranslateUciCastling(body, board);
+    if (uciCastling != null) {
+      codes.add(LenientSanValidationProblem.UCI_NOTATION);
+      return uciCastling + marker;
+    }
+
+    return null;
+  }
+
+  private static boolean matchesCastlingZeroOPattern(String body) {
+    if (body.length() == 3) {
+      return isZeroOrO(body.charAt(0)) && body.charAt(1) == '-' && isZeroOrO(body.charAt(2));
+    }
+    if (body.length() == 5) {
+      return isZeroOrO(body.charAt(0)) && body.charAt(1) == '-' && isZeroOrO(body.charAt(2)) && body.charAt(3) == '-'
+          && isZeroOrO(body.charAt(4));
+    }
+    return false;
+  }
+
+  private static boolean isZeroOrO(char c) {
+    return c == '0' || c == 'O';
+  }
+
+  private static String tryTranslateUciCastling(String body, ChessBoard board) {
+    if (body.length() != 4) {
+      return null;
+    }
+    if (!isFileLetter(body.charAt(0)) || !isRankDigit(body.charAt(1)) || !isFileLetter(body.charAt(2))
+        || !isRankDigit(body.charAt(3))) {
+      return null;
+    }
+    final Square from = parseSquare(body.charAt(0), body.charAt(1));
+    final Square to = parseSquare(body.charAt(2), body.charAt(3));
+    if (from == Square.NONE || to == Square.NONE) {
+      return null;
+    }
+    final StaticPosition position = board.getStaticPosition();
+    final Piece piece = position.get(from);
+    if (piece == Piece.NONE || piece.getPieceType() != PieceType.KING) {
+      return null;
+    }
+    if (from == Square.E1 && to == Square.G1) {
+      return "O-O";
+    }
+    if (from == Square.E1 && to == Square.C1) {
+      return "O-O-O";
+    }
+    if (from == Square.E8 && to == Square.G8) {
+      return "O-O";
+    }
+    if (from == Square.E8 && to == Square.C8) {
+      return "O-O-O";
+    }
+    return null;
+  }
+
+  // --- LAN / UCI handling (mutually exclusive at the input level) ---
+  //
+  // LAN-with-hyphen ("e2-e4", "Nb1-d7") and UCI ("e2e4", "b1d7") use overlapping pure-string shapes; without
+  // the hyphen, pawn LAN is identical to pawn UCI. We disambiguate by the presence of a hyphen in the input:
+  // a hyphen means LAN (only LONG_ALGEBRAIC_NOTATION code); no hyphen means UCI shape (only UCI_NOTATION code).
+  // Either branch may then translate to canonical SAN; the translation itself does not emit a second code.
+
+  private static String handleLanOrUci(String body, ChessBoard board, List<LenientSanValidationProblem> codes) {
+    if (body.indexOf('-') >= 0) {
+      final String dehyphenated = body.replace("-", "");
+      codes.add(LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION);
+      final String translated = tryTranslateUciShape(dehyphenated, board);
+      return translated != null ? translated : dehyphenated;
+    }
+    final String translated = tryTranslateUciShape(body, board);
+    if (translated != null) {
+      codes.add(LenientSanValidationProblem.UCI_NOTATION);
+      return translated;
+    }
+    return body;
+  }
+
+  /**
+   * Translates a UCI-shape string (4 or 5 chars, no piece letter, file/rank/file/rank/optional-promotion) to canonical
+   * SAN using the piece on the from-square. Returns {@code null} when the shape doesn't match — the caller decides
+   * whether that means "leave the body unchanged" or "this branch doesn't apply."
+   */
+  private static String tryTranslateUciShape(String body, ChessBoard board) {
+    if (body.length() != 4 && body.length() != 5) {
+      return null;
+    }
+    if (!isFileLetter(body.charAt(0)) || !isRankDigit(body.charAt(1)) || !isFileLetter(body.charAt(2))
+        || !isRankDigit(body.charAt(3))) {
+      return null;
+    }
+    if (body.length() == 5 && !isPromotionPieceLetterAnyCase(body.charAt(4))) {
+      return null;
+    }
+    final Square from = parseSquare(body.charAt(0), body.charAt(1));
+    final Square to = parseSquare(body.charAt(2), body.charAt(3));
+    if (from == Square.NONE || to == Square.NONE || from == to) {
+      return null;
+    }
+    final StaticPosition position = board.getStaticPosition();
+    final Piece piece = position.get(from);
+    if (piece == Piece.NONE) {
+      return null;
+    }
+    final PieceType pieceType = piece.getPieceType();
+
+    final StringBuilder out = new StringBuilder();
+    if (pieceType == PieceType.PAWN) {
+      // Pawn SAN: forward "<file><rank>", capture "<fromFile>x<toFile><toRank>", optional "=<P>"
+      final boolean isCapture = body.charAt(0) != body.charAt(2);
+      if (isCapture) {
+        out.append(body.charAt(0)).append('x').append(body.charAt(2)).append(body.charAt(3));
+      } else {
+        out.append(body.charAt(2)).append(body.charAt(3));
+      }
+      if (body.length() == 5) {
+        out.append('=').append(Character.toUpperCase(body.charAt(4)));
+      }
+    } else {
+      // Non-pawn SAN with full square disambiguation. The destination capture-marker is unknown without
+      // walking destination semantics; let Phase 2 add it via MISSING_CAPTURE_MARKER if needed.
+      out.append(pieceType.getLetter());
+      out.append(body.charAt(0)).append(body.charAt(1));
+      out.append(body.charAt(2)).append(body.charAt(3));
+    }
+    return NonNullWrapperCommon.toString(out);
+  }
+
+  // --- Body transforms ---
+
+  private static String stripExplicitPawnLetter(String body, List<LenientSanValidationProblem> codes) {
+    if (body.length() < 2 || body.charAt(0) != 'P') {
+      return body;
+    }
+    if (!isFileLetter(body.charAt(1))) {
+      return body;
+    }
+    codes.add(LenientSanValidationProblem.EXPLICIT_PAWN_LETTER);
+    return NonNullWrapperCommon.substring(body, 1);
+  }
+
+  private static String insertMissingPromotionEquals(String body, List<LenientSanValidationProblem> codes) {
+    final int len = body.length();
+    if (len < 3) {
+      return body;
+    }
+    final char last = body.charAt(len - 1);
+    if (!isPromotionPieceLetterAnyCase(last)) {
+      return body;
+    }
+    final char prev = body.charAt(len - 2);
+    if (prev != '1' && prev != '8') {
+      return body;
+    }
+    if (len >= 3 && body.charAt(len - 3) == '=') {
+      return body;
+    }
+    codes.add(LenientSanValidationProblem.MISSING_PROMOTION_EQUALS);
+    return NonNullWrapperCommon.substring(body, 0, len - 1) + "=" + last;
+  }
+
+  private static String applyCaseFixups(String body, List<LenientSanValidationProblem> codes) {
+    String result = body;
+    result = caseFixUppercaseCaptureMarker(result, codes);
+    result = caseFixLowercasePromotionPiece(result, codes);
+    result = caseFixLowercasePieceLetter(result, codes);
+    result = caseFixUppercaseFileLetters(result, codes);
+    return result;
+  }
+
+  private static String caseFixUppercaseCaptureMarker(String body, List<LenientSanValidationProblem> codes) {
+    if (body.indexOf('X') < 0) {
+      return body;
+    }
+    codes.add(LenientSanValidationProblem.UPPERCASE_CAPTURE_MARKER);
+    return body.replace('X', 'x');
+  }
+
+  private static String caseFixLowercasePromotionPiece(String body, List<LenientSanValidationProblem> codes) {
+    final int eq = body.lastIndexOf('=');
+    if (eq < 0 || eq != body.length() - 2) {
+      return body;
+    }
+    final char piece = body.charAt(eq + 1);
+    if (piece == 'r' || piece == 'n' || piece == 'b' || piece == 'q') {
+      codes.add(LenientSanValidationProblem.LOWERCASE_PROMOTION_PIECE);
+      return NonNullWrapperCommon.substring(body, 0, eq + 1) + Character.toUpperCase(piece);
+    }
+    return body;
+  }
+
+  private static String caseFixLowercasePieceLetter(String body, List<LenientSanValidationProblem> codes) {
+    if (body.isEmpty()) {
+      return body;
+    }
+    final char first = body.charAt(0);
+    if (first == 'n' || first == 'r' || first == 'q' || first == 'k') {
+      codes.add(LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
+      return Character.toUpperCase(first) + NonNullWrapperCommon.substring(body, 1);
+    }
+    if (first == 'b') {
+      // Ambiguous: 'b' is both a file letter (canonical pawn move) and a lowercase bishop letter.
+      // We get here only because Phase 0 (raw strict) already failed, so the input is not a valid pawn move.
+      // Treat as bishop and case-fold.
+      codes.add(LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
+      return "B" + NonNullWrapperCommon.substring(body, 1);
+    }
+    return body;
+  }
+
+  private static String caseFixUppercaseFileLetters(String body, List<LenientSanValidationProblem> codes) {
+    final StringBuilder out = new StringBuilder(body.length());
+    boolean changed = false;
+    for (var i = 0; i < body.length(); i++) {
+      final char c = body.charAt(i);
+      // First character: piece letter is canonically uppercase, never a file letter; skip case fix here.
+      if (i == 0) {
+        out.append(c);
+        continue;
+      }
+      if (isUppercaseFileLetter(c)) {
+        out.append(Character.toLowerCase(c));
+        changed = true;
+      } else {
+        out.append(c);
+      }
+    }
+    if (changed) {
+      codes.add(LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
+      return NonNullWrapperCommon.toString(out);
+    }
+    return body;
+  }
+
+  // --- Character helpers ---
+
+  private static boolean isFileLetter(char c) {
+    return c >= 'a' && c <= 'h';
+  }
+
+  private static boolean isRankDigit(char c) {
+    return c >= '1' && c <= '8';
+  }
+
+  private static boolean isUppercaseFileLetter(char c) {
+    return c >= 'A' && c <= 'H';
+  }
+
+  private static boolean isPromotionPieceLetterAnyCase(char c) {
+    return c == 'R' || c == 'N' || c == 'B' || c == 'Q' || c == 'r' || c == 'n' || c == 'b' || c == 'q';
+  }
+
+  private static Square parseSquare(char fileLetter, char rankDigit) {
+    try {
+      return Square.valueOf(("" + fileLetter + rankDigit).toUpperCase(java.util.Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new ProgrammingMistakeException("Square.valueOf failed for validated file/rank chars", e);
+    }
+  }
+}

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
@@ -294,17 +294,30 @@ final class LenientSanShapeNormalize {
     }
     if (first == 'b') {
       // Lowercase 'b' is canonically a file letter (pawn move from b-file) or the file leader of a UCI / LAN
-      // form (e.g. "b1c3"). The only shape that points unambiguously to a lowercase bishop letter is
-      // <piece><file>... — i.e. position 1 is a file letter (e.g. "bf3" = bishop to f3, "bxc4" but with x at
-      // position 1 we treat as pawn capture, not bishop, since pawn capture is the canonical reading of
-      // "<file>x..."). Anything else (rank digit at position 1, length 2, etc.) we leave as pawn / file.
+      // form (e.g. "b1c3"). Two shapes point at a lowercase bishop letter:
+      //
+      // (a) <piece><file>... — position 1 is a file letter (e.g. "bf3" = bishop to f3, "bdxe5" = bishop with
+      //     file disambig and capture). Pawn moves never have a file letter at position 1.
+      // (b) bx<file><rank> with non-adjacent files — pawn captures must be diagonal, so b-pawn can only
+      //     capture on a- or c-file. If the capture destination file is not adjacent to b, the pawn
+      //     interpretation is geometrically illegal regardless of board state, and the user must mean a
+      //     lowercase bishop capture (e.g. "bxf7" — bishop on c4 captures on f7).
       if (body.length() >= 2 && isFileLetterAnyCase(body.charAt(1))) {
+        codes.add(LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
+        return "B" + NonNullWrapperCommon.substring(body, 1);
+      }
+      if (body.length() >= 4 && body.charAt(1) == 'x' && isFileLetterAnyCase(body.charAt(2))
+          && !isAdjacentFile('b', Character.toLowerCase(body.charAt(2)))) {
         codes.add(LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
         return "B" + NonNullWrapperCommon.substring(body, 1);
       }
       return body;
     }
     return body;
+  }
+
+  private static boolean isAdjacentFile(char a, char b) {
+    return Math.abs((int) a - (int) b) == 1;
   }
 
   private static String caseFixUppercaseFileLetters(String body, List<LenientSanValidationProblem> codes) {
@@ -350,6 +363,7 @@ final class LenientSanShapeNormalize {
    * <ul>
    * <li>{@code B<rank>} (length 2) — bishop has no length-2 SAN form
    * <li>{@code B<rank>=<piece>} (length 4 promotion) — bishops don't promote
+   * <li>{@code Bx<file><rank><piece>} (length 5 capture promotion missing {@code =}) — bishops don't promote
    * <li>{@code Bx<file><rank>=<piece>} (length 6 capture promotion) — bishops don't promote
    * </ul>
    * Capture and disambiguation forms (e.g. {@code Bxf7}, {@code B1d4}) are canonically bishop, even though they
@@ -362,6 +376,13 @@ final class LenientSanShapeNormalize {
     if (body.length() == 4) {
       return isRankDigit(body.charAt(1)) && body.charAt(2) == '='
           && isPromotionPieceLetterAnyCase(body.charAt(3));
+    }
+    if (body.length() == 5) {
+      // Bx<file><rank><piece>: capture promotion missing the '=' marker — bishops don't promote, so this is
+      // unambiguously an uppercase b-file pawn capture promotion.
+      return body.charAt(1) == 'x' && isFileLetterAnyCase(body.charAt(2))
+          && (body.charAt(3) == '1' || body.charAt(3) == '8')
+          && isPromotionPieceLetterAnyCase(body.charAt(4));
     }
     if (body.length() == 6) {
       return body.charAt(1) == 'x' && isFileLetterAnyCase(body.charAt(2)) && isRankDigit(body.charAt(3))

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
@@ -80,7 +80,7 @@ final class LenientSanShapeNormalize {
       if (hasO && hasZero) {
         throw new LenientSanParserValidationException(
             Message.getString("validation.san.lenient.mixedCastlingZeroAndO", text), text, null,
-            NonNullWrapperCommon.copyOfList(List.<ForgivenItem>of()));
+            ForgivenItem.EMPTY_LIST);
       }
       if (hasZero) {
         codes.add(LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING);

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
@@ -43,15 +43,15 @@ final class LenientSanShapeNormalize {
       return text;
     }
 
-    final @Nullable String castlingNormalized = tryNormalizeCastling(text, board, codes);
+    final var castlingNormalized = tryNormalizeCastling(text, board, codes);
     if (castlingNormalized != null) {
       return castlingNormalized;
     }
 
-    final char lastChar = text.charAt(text.length() - 1);
-    final boolean hasTerminalMarker = lastChar == '+' || lastChar == '#';
-    final String terminalMarker = hasTerminalMarker ? NonNullWrapperCommon.valueOf(lastChar) : "";
-    String body = hasTerminalMarker ? NonNullWrapperCommon.substring(text, 0, text.length() - 1) : text;
+    final var lastChar = text.charAt(text.length() - 1);
+    final var hasTerminalMarker = lastChar == '+' || lastChar == '#';
+    final var terminalMarker = hasTerminalMarker ? NonNullWrapperCommon.valueOf(lastChar) : "";
+    var body = hasTerminalMarker ? NonNullWrapperCommon.substring(text, 0, text.length() - 1) : text;
 
     body = stripExplicitPawnLetter(body, codes);
     // Case fixes run early so downstream steps (UCI/LAN translation, pawn-missing-x, promotion-equals)
@@ -68,15 +68,15 @@ final class LenientSanShapeNormalize {
 
   private static @Nullable String tryNormalizeCastling(String text, ChessBoard board,
       List<LenientSanValidationProblem> codes) {
-    final char lastChar = text.charAt(text.length() - 1);
-    final boolean hasTerminalMarker = lastChar == '+' || lastChar == '#';
-    final String marker = hasTerminalMarker ? NonNullWrapperCommon.valueOf(lastChar) : "";
-    final String body = hasTerminalMarker ? NonNullWrapperCommon.substring(text, 0, text.length() - 1) : text;
+    final var lastChar = text.charAt(text.length() - 1);
+    final var hasTerminalMarker = lastChar == '+' || lastChar == '#';
+    final var marker = hasTerminalMarker ? NonNullWrapperCommon.valueOf(lastChar) : "";
+    final var body = hasTerminalMarker ? NonNullWrapperCommon.substring(text, 0, text.length() - 1) : text;
 
     // Classic O-O / 0-0 / mixed forms. Three or five characters with hyphens and zero-or-O at every other position.
     if (matchesCastlingZeroOPattern(body)) {
-      final boolean hasO = body.indexOf('O') >= 0;
-      final boolean hasZero = body.indexOf('0') >= 0;
+      final var hasO = body.indexOf('O') >= 0;
+      final var hasZero = body.indexOf('0') >= 0;
       if (hasO && hasZero) {
         throw new LenientSanParserValidationException(
             Message.getString("validation.san.lenient.mixedCastlingZeroAndO", text), text, null,
@@ -91,7 +91,7 @@ final class LenientSanShapeNormalize {
     }
 
     // UCI king-castling: e1g1 / e1c1 / e8g8 / e8c8 with the king actually on the e-file home square.
-    final @Nullable String uciCastling = tryTranslateUciCastling(body, board);
+    final var uciCastling = tryTranslateUciCastling(body, board);
     if (uciCastling != null) {
       codes.add(LenientSanValidationProblem.UCI_NOTATION);
       return uciCastling + marker;
@@ -159,10 +159,10 @@ final class LenientSanShapeNormalize {
     if (body.indexOf('-') >= 0) {
       final String dehyphenated = NonNullWrapperCommon.replace(body, "-", "");
       codes.add(LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION);
-      final @Nullable String translated = tryTranslateUciShape(dehyphenated, board);
+      final var translated = tryTranslateUciShape(dehyphenated, board);
       return translated != null ? translated : dehyphenated;
     }
-    final @Nullable String translated = tryTranslateUciShape(body, board);
+    final var translated = tryTranslateUciShape(body, board);
     if (translated != null) {
       codes.add(LenientSanValidationProblem.UCI_NOTATION);
       return translated;
@@ -201,7 +201,7 @@ final class LenientSanShapeNormalize {
     final StringBuilder out = new StringBuilder();
     if (pieceType == PieceType.PAWN) {
       // Pawn SAN: forward "<file><rank>", capture "<fromFile>x<toFile><toRank>", optional "=<P>"
-      final boolean isCapture = body.charAt(0) != body.charAt(2);
+      final var isCapture = body.charAt(0) != body.charAt(2);
       if (isCapture) {
         out.append(body.charAt(0)).append('x').append(body.charAt(2)).append(body.charAt(3));
       } else {
@@ -223,10 +223,7 @@ final class LenientSanShapeNormalize {
   // --- Body transforms ---
 
   private static String stripExplicitPawnLetter(String body, List<LenientSanValidationProblem> codes) {
-    if (body.length() < 2 || body.charAt(0) != 'P') {
-      return body;
-    }
-    if (!isFileLetter(body.charAt(1))) {
+    if (body.length() < 2 || body.charAt(0) != 'P' || !isFileLetter(body.charAt(1))) {
       return body;
     }
     codes.add(LenientSanValidationProblem.EXPLICIT_PAWN_LETTER);
@@ -234,19 +231,16 @@ final class LenientSanShapeNormalize {
   }
 
   private static String insertMissingPromotionEquals(String body, List<LenientSanValidationProblem> codes) {
-    final int len = body.length();
+    final var len = body.length();
     if (len < 3) {
       return body;
     }
-    final char last = body.charAt(len - 1);
+    final var last = body.charAt(len - 1);
     if (!isPromotionPieceLetterAnyCase(last)) {
       return body;
     }
-    final char prev = body.charAt(len - 2);
-    if (prev != '1' && prev != '8') {
-      return body;
-    }
-    if (body.charAt(len - 3) == '=') {
+    final var prev = body.charAt(len - 2);
+    if (prev != '1' && prev != '8' || body.charAt(len - 3) == '=') {
       return body;
     }
     codes.add(LenientSanValidationProblem.MISSING_PROMOTION_EQUALS);
@@ -271,11 +265,11 @@ final class LenientSanShapeNormalize {
   }
 
   private static String caseFixLowercasePromotionPiece(String body, List<LenientSanValidationProblem> codes) {
-    final int eq = body.lastIndexOf('=');
+    final var eq = body.lastIndexOf('=');
     if (eq < 0 || eq != body.length() - 2) {
       return body;
     }
-    final char piece = body.charAt(eq + 1);
+    final var piece = body.charAt(eq + 1);
     if (piece == 'r' || piece == 'n' || piece == 'b' || piece == 'q') {
       codes.add(LenientSanValidationProblem.LOWERCASE_PROMOTION_PIECE);
       return NonNullWrapperCommon.substring(body, 0, eq + 1) + Character.toUpperCase(piece);
@@ -287,7 +281,7 @@ final class LenientSanShapeNormalize {
     if (body.isEmpty()) {
       return body;
     }
-    final char first = body.charAt(0);
+    final var first = body.charAt(0);
     if (first == 'n' || first == 'r' || first == 'q' || first == 'k') {
       codes.add(LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
       return Character.toUpperCase(first) + NonNullWrapperCommon.substring(body, 1);
@@ -297,11 +291,11 @@ final class LenientSanShapeNormalize {
       // form (e.g. "b1c3"). Two shapes point at a lowercase bishop letter:
       //
       // (a) <piece><file>... — position 1 is a file letter (e.g. "bf3" = bishop to f3, "bdxe5" = bishop with
-      //     file disambig and capture). Pawn moves never have a file letter at position 1.
+      // file disambig and capture). Pawn moves never have a file letter at position 1.
       // (b) bx<file><rank> with non-adjacent files — pawn captures must be diagonal, so b-pawn can only
-      //     capture on a- or c-file. If the capture destination file is not adjacent to b, the pawn
-      //     interpretation is geometrically illegal regardless of board state, and the user must mean a
-      //     lowercase bishop capture (e.g. "bxf7" — bishop on c4 captures on f7).
+      // capture on a- or c-file. If the capture destination file is not adjacent to b, the pawn
+      // interpretation is geometrically illegal regardless of board state, and the user must mean a
+      // lowercase bishop capture (e.g. "bxf7" — bishop on c4 captures on f7).
       if (body.length() >= 2 && isFileLetterAnyCase(body.charAt(1))) {
         codes.add(LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
         return "B" + NonNullWrapperCommon.substring(body, 1);
@@ -311,20 +305,19 @@ final class LenientSanShapeNormalize {
         codes.add(LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
         return "B" + NonNullWrapperCommon.substring(body, 1);
       }
-      return body;
     }
     return body;
   }
 
   private static boolean isAdjacentFile(char a, char b) {
-    return Math.abs((int) a - (int) b) == 1;
+    return Math.abs(a - b) == 1;
   }
 
   private static String caseFixUppercaseFileLetters(String body, List<LenientSanValidationProblem> codes) {
     final StringBuilder out = new StringBuilder(body.length());
-    boolean changed = false;
+    var changed = false;
     for (var i = 0; i < body.length(); i++) {
-      final char c = body.charAt(i);
+      final var c = body.charAt(i);
       if (i == 0) {
         // Position 0 may be a piece letter (P, R, N, B, Q, K) OR a file letter for pawn / UCI / LAN forms.
         // A, C, D, E, F, G, H are unambiguously file letters (no piece uses these). B is ambiguous (file b
@@ -357,8 +350,8 @@ final class LenientSanShapeNormalize {
   }
 
   /**
-   * Returns true when {@code body} starts with uppercase {@code B} but the rest of the shape is incompatible with
-   * any valid bishop SAN — i.e. only the b-file pawn interpretation makes sense. Used to decide whether an uppercase
+   * Returns true when {@code body} starts with uppercase {@code B} but the rest of the shape is incompatible with any
+   * valid bishop SAN — i.e. only the b-file pawn interpretation makes sense. Used to decide whether an uppercase
    * {@code B} at position 0 should be lowercased. The shapes that pass here are:
    * <ul>
    * <li>{@code B<rank>} (length 2) — bishop has no length-2 SAN form
@@ -366,23 +359,21 @@ final class LenientSanShapeNormalize {
    * <li>{@code Bx<file><rank><piece>} (length 5 capture promotion missing {@code =}) — bishops don't promote
    * <li>{@code Bx<file><rank>=<piece>} (length 6 capture promotion) — bishops don't promote
    * </ul>
-   * Capture and disambiguation forms (e.g. {@code Bxf7}, {@code B1d4}) are canonically bishop, even though they
-   * could lexically also be uppercase b-file pawn forms; the case carries the user's intent and we respect it.
+   * Capture and disambiguation forms (e.g. {@code Bxf7}, {@code B1d4}) are canonically bishop, even though they could
+   * lexically also be uppercase b-file pawn forms; the case carries the user's intent and we respect it.
    */
   private static boolean isUppercaseBPawnOnlyShape(String body) {
     if (body.length() == 2) {
       return isRankDigit(body.charAt(1));
     }
     if (body.length() == 4) {
-      return isRankDigit(body.charAt(1)) && body.charAt(2) == '='
-          && isPromotionPieceLetterAnyCase(body.charAt(3));
+      return isRankDigit(body.charAt(1)) && body.charAt(2) == '=' && isPromotionPieceLetterAnyCase(body.charAt(3));
     }
     if (body.length() == 5) {
       // Bx<file><rank><piece>: capture promotion missing the '=' marker — bishops don't promote, so this is
       // unambiguously an uppercase b-file pawn capture promotion.
       return body.charAt(1) == 'x' && isFileLetterAnyCase(body.charAt(2))
-          && (body.charAt(3) == '1' || body.charAt(3) == '8')
-          && isPromotionPieceLetterAnyCase(body.charAt(4));
+          && (body.charAt(3) == '1' || body.charAt(3) == '8') && isPromotionPieceLetterAnyCase(body.charAt(4));
     }
     if (body.length() == 6) {
       return body.charAt(1) == 'x' && isFileLetterAnyCase(body.charAt(2)) && isRankDigit(body.charAt(3))
@@ -396,10 +387,10 @@ final class LenientSanShapeNormalize {
   }
 
   /**
-   * Detects pawn captures written without the {@code x} marker: {@code <file><file><rank>} (3 chars, e.g.
-   * {@code ed5}), {@code <file><file><rank>=<piece>} (5 chars, e.g. {@code ed8=Q}), or
-   * {@code <file><file><rank><piece>} (4 chars with rank 1/8, e.g. {@code ed8Q} — capture promotion missing both
-   * x and =). Inserts {@code x} at position 1 and emits {@link LenientSanValidationProblem#MISSING_CAPTURE_MARKER}.
+   * Detects pawn captures written without the {@code x} marker: {@code <file><file><rank>} (3 chars, e.g. {@code ed5}),
+   * {@code <file><file><rank>=<piece>} (5 chars, e.g. {@code ed8=Q}), or {@code <file><file><rank><piece>} (4 chars
+   * with rank 1/8, e.g. {@code ed8Q} — capture promotion missing both x and =). Inserts {@code x} at position 1 and
+   * emits {@link LenientSanValidationProblem#MISSING_CAPTURE_MARKER}.
    */
   private static String insertMissingPawnCaptureMarker(String body, List<LenientSanValidationProblem> codes) {
     if (body.length() == 3 && isFileLetter(body.charAt(0)) && isFileLetter(body.charAt(1))
@@ -441,7 +432,7 @@ final class LenientSanShapeNormalize {
   private static Square parseSquare(char fileLetter, char rankDigit) {
     try {
       return Square.valueOf(NonNullWrapperCommon.toUpperCase("" + fileLetter + rankDigit));
-    } catch (IllegalArgumentException e) {
+    } catch (final IllegalArgumentException e) {
       throw new ProgrammingMistakeException("Square.valueOf failed for validated file/rank chars", e);
     }
   }

--- a/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
+++ b/src/main/java/com/dlb/chess/san/lenient/LenientSanShapeNormalize.java
@@ -54,9 +54,12 @@ final class LenientSanShapeNormalize {
     String body = hasTerminalMarker ? NonNullWrapperCommon.substring(text, 0, text.length() - 1) : text;
 
     body = stripExplicitPawnLetter(body, codes);
-    body = handleLanOrUci(body, board, codes);
-    body = insertMissingPromotionEquals(body, codes);
+    // Case fixes run early so downstream steps (UCI/LAN translation, pawn-missing-x, promotion-equals)
+    // see lowercase-normalized files and can match shape unambiguously.
     body = applyCaseFixups(body, codes);
+    body = handleLanOrUci(body, board, codes);
+    body = insertMissingPawnCaptureMarker(body, codes);
+    body = insertMissingPromotionEquals(body, codes);
 
     return body + terminalMarker;
   }
@@ -290,11 +293,16 @@ final class LenientSanShapeNormalize {
       return Character.toUpperCase(first) + NonNullWrapperCommon.substring(body, 1);
     }
     if (first == 'b') {
-      // Ambiguous: 'b' is both a file letter (canonical pawn move) and a lowercase bishop letter.
-      // We get here only because Phase 0 (raw strict) already failed, so the input is not a valid pawn move.
-      // Treat as bishop and case-fold.
-      codes.add(LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
-      return "B" + NonNullWrapperCommon.substring(body, 1);
+      // Lowercase 'b' is canonically a file letter (pawn move from b-file) or the file leader of a UCI / LAN
+      // form (e.g. "b1c3"). The only shape that points unambiguously to a lowercase bishop letter is
+      // <piece><file>... — i.e. position 1 is a file letter (e.g. "bf3" = bishop to f3, "bxc4" but with x at
+      // position 1 we treat as pawn capture, not bishop, since pawn capture is the canonical reading of
+      // "<file>x..."). Anything else (rank digit at position 1, length 2, etc.) we leave as pawn / file.
+      if (body.length() >= 2 && isFileLetterAnyCase(body.charAt(1))) {
+        codes.add(LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
+        return "B" + NonNullWrapperCommon.substring(body, 1);
+      }
+      return body;
     }
     return body;
   }
@@ -304,8 +312,20 @@ final class LenientSanShapeNormalize {
     boolean changed = false;
     for (var i = 0; i < body.length(); i++) {
       final char c = body.charAt(i);
-      // First character: piece letter is canonically uppercase, never a file letter; skip case fix here.
       if (i == 0) {
+        // Position 0 may be a piece letter (P, R, N, B, Q, K) OR a file letter for pawn / UCI / LAN forms.
+        // A, C, D, E, F, G, H are unambiguously file letters (no piece uses these). B is ambiguous (file b
+        // vs bishop) — only fold to file when the body shape is pawn-compatible.
+        if (c >= 'A' && c <= 'H' && c != 'B') {
+          out.append(Character.toLowerCase(c));
+          changed = true;
+          continue;
+        }
+        if (c == 'B' && isUppercaseBPawnOnlyShape(body)) {
+          out.append('b');
+          changed = true;
+          continue;
+        }
         out.append(c);
         continue;
       }
@@ -319,6 +339,62 @@ final class LenientSanShapeNormalize {
     if (changed) {
       codes.add(LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
       return NonNullWrapperCommon.toString(out);
+    }
+    return body;
+  }
+
+  /**
+   * Returns true when {@code body} starts with uppercase {@code B} but the rest of the shape is incompatible with
+   * any valid bishop SAN — i.e. only the b-file pawn interpretation makes sense. Used to decide whether an uppercase
+   * {@code B} at position 0 should be lowercased. The shapes that pass here are:
+   * <ul>
+   * <li>{@code B<rank>} (length 2) — bishop has no length-2 SAN form
+   * <li>{@code B<rank>=<piece>} (length 4 promotion) — bishops don't promote
+   * <li>{@code Bx<file><rank>=<piece>} (length 6 capture promotion) — bishops don't promote
+   * </ul>
+   * Capture and disambiguation forms (e.g. {@code Bxf7}, {@code B1d4}) are canonically bishop, even though they
+   * could lexically also be uppercase b-file pawn forms; the case carries the user's intent and we respect it.
+   */
+  private static boolean isUppercaseBPawnOnlyShape(String body) {
+    if (body.length() == 2) {
+      return isRankDigit(body.charAt(1));
+    }
+    if (body.length() == 4) {
+      return isRankDigit(body.charAt(1)) && body.charAt(2) == '='
+          && isPromotionPieceLetterAnyCase(body.charAt(3));
+    }
+    if (body.length() == 6) {
+      return body.charAt(1) == 'x' && isFileLetterAnyCase(body.charAt(2)) && isRankDigit(body.charAt(3))
+          && body.charAt(4) == '=' && isPromotionPieceLetterAnyCase(body.charAt(5));
+    }
+    return false;
+  }
+
+  private static boolean isFileLetterAnyCase(char c) {
+    return c >= 'a' && c <= 'h' || c >= 'A' && c <= 'H';
+  }
+
+  /**
+   * Detects pawn captures written without the {@code x} marker: {@code <file><file><rank>} (3 chars, e.g.
+   * {@code ed5}), {@code <file><file><rank>=<piece>} (5 chars, e.g. {@code ed8=Q}), or
+   * {@code <file><file><rank><piece>} (4 chars with rank 1/8, e.g. {@code ed8Q} — capture promotion missing both
+   * x and =). Inserts {@code x} at position 1 and emits {@link LenientSanValidationProblem#MISSING_CAPTURE_MARKER}.
+   */
+  private static String insertMissingPawnCaptureMarker(String body, List<LenientSanValidationProblem> codes) {
+    if (body.length() == 3 && isFileLetter(body.charAt(0)) && isFileLetter(body.charAt(1))
+        && isRankDigit(body.charAt(2))) {
+      codes.add(LenientSanValidationProblem.MISSING_CAPTURE_MARKER);
+      return body.charAt(0) + "x" + NonNullWrapperCommon.substring(body, 1);
+    }
+    if (body.length() == 4 && isFileLetter(body.charAt(0)) && isFileLetter(body.charAt(1))
+        && (body.charAt(2) == '1' || body.charAt(2) == '8') && isPromotionPieceLetterAnyCase(body.charAt(3))) {
+      codes.add(LenientSanValidationProblem.MISSING_CAPTURE_MARKER);
+      return body.charAt(0) + "x" + NonNullWrapperCommon.substring(body, 1);
+    }
+    if (body.length() == 5 && isFileLetter(body.charAt(0)) && isFileLetter(body.charAt(1))
+        && isRankDigit(body.charAt(2)) && body.charAt(3) == '=' && isPromotionPieceLetterAnyCase(body.charAt(4))) {
+      codes.add(LenientSanValidationProblem.MISSING_CAPTURE_MARKER);
+      return body.charAt(0) + "x" + NonNullWrapperCommon.substring(body, 1);
     }
     return body;
   }

--- a/src/main/java/com/dlb/chess/san/lenient/package-info.java
+++ b/src/main/java/com/dlb/chess/san/lenient/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Lenient SAN parser. Accepts inputs the strict {@link com.dlb.chess.san.validate.SanValidation} pipeline rejects, when
+ * Lenient SAN parser. Accepts inputs the strict {@link com.dlb.chess.san.validate.StrictSanParser} pipeline rejects, when
  * those inputs uniquely identify a legal move and the deviation matches one of the supported tolerance categories
  * enumerated in {@link com.dlb.chess.san.enums.LenientSanValidationProblem}.
  *

--- a/src/main/java/com/dlb/chess/san/lenient/package-info.java
+++ b/src/main/java/com/dlb/chess/san/lenient/package-info.java
@@ -1,0 +1,27 @@
+/**
+ * Lenient SAN parser. Accepts inputs the strict {@link com.dlb.chess.san.validate.SanValidation} pipeline rejects, when
+ * those inputs uniquely identify a legal move and the deviation matches one of the supported tolerance categories
+ * enumerated in {@link com.dlb.chess.san.enums.LenientSanValidationProblem}.
+ *
+ * <p>
+ * Strategy is two-phase, canonical-first:
+ * <ol>
+ * <li>Try the strict pipeline as-is. If it accepts, the input was canonical SAN and the result has no forgiven items.
+ * <li>If the strict pipeline rejects, apply pure-string shape normalization (case fixups, castling-zero, UCI / LAN
+ * translation, explicit pawn letter, missing promotion equals, etc.), accumulating one forgiven item per detected
+ * deviation.
+ * <li>Re-run the strict pipeline on the normalized candidate. If it rejects with a recoverable diagnostic
+ * (over-specification, capture-marker mismatch, terminal-marker mismatch), mutate the candidate, accumulate another
+ * forgiven item, and retry. If the final rejection is non-recoverable, throw
+ * {@link com.dlb.chess.san.exceptions.LenientSanParserValidationException} carrying the deepest underlying strict
+ * reason and the partial forgiven-items list.
+ * </ol>
+ *
+ * <p>
+ * The strict pipeline is reused unchanged for all chess-validation logic; this package contains only the input-shape
+ * transformations and the recovery loop.
+ */
+@NonNullByDefault
+package com.dlb.chess.san.lenient;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/src/main/java/com/dlb/chess/san/model/ForgivenItem.java
+++ b/src/main/java/com/dlb/chess/san/model/ForgivenItem.java
@@ -1,6 +1,9 @@
 package com.dlb.chess.san.model;
 
+import org.eclipse.jdt.annotation.NonNull;
+
 import com.dlb.chess.san.enums.LenientSanValidationProblem;
+import com.google.common.collect.ImmutableList;
 
 /**
  * One forgiven deviation surfaced by the lenient SAN parser.
@@ -10,6 +13,14 @@ import com.dlb.chess.san.enums.LenientSanValidationProblem;
  * @param canonicalSan the canonical SAN equivalent the parser resolved the input to
  */
 public record ForgivenItem(LenientSanValidationProblem code, String originalToken, String canonicalSan) {
+
+  /**
+   * Shared empty list for the "no deviations forgiven" case. Centralised here so the {@code @NonNull} suppression on
+   * Guava's {@code ImmutableList.of()} (which JDT can't statically prove is non-null with non-null elements) lives in
+   * one place rather than at every caller.
+   */
+  @SuppressWarnings("null")
+  public static final @NonNull ImmutableList<@NonNull ForgivenItem> EMPTY_LIST = ImmutableList.of();
 
   public ForgivenItem {
     if (originalToken.isBlank()) {

--- a/src/main/java/com/dlb/chess/san/model/ForgivenItem.java
+++ b/src/main/java/com/dlb/chess/san/model/ForgivenItem.java
@@ -1,0 +1,22 @@
+package com.dlb.chess.san.model;
+
+import com.dlb.chess.san.enums.LenientSanValidationProblem;
+
+/**
+ * One forgiven deviation surfaced by the lenient SAN parser.
+ *
+ * @param code the typed deviation classifier
+ * @param originalToken the original SAN token as the user wrote it (the entire move, not just the deviating fragment)
+ * @param canonicalSan the canonical SAN equivalent the parser resolved the input to
+ */
+public record ForgivenItem(LenientSanValidationProblem code, String originalToken, String canonicalSan) {
+
+  public ForgivenItem {
+    if (originalToken.isBlank()) {
+      throw new IllegalArgumentException("originalToken must not be blank");
+    }
+    if (canonicalSan.isBlank()) {
+      throw new IllegalArgumentException("canonicalSan must not be blank");
+    }
+  }
+}

--- a/src/main/java/com/dlb/chess/san/model/LenientSanParserValidationResult.java
+++ b/src/main/java/com/dlb/chess/san/model/LenientSanParserValidationResult.java
@@ -1,0 +1,20 @@
+package com.dlb.chess.san.model;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+import com.dlb.chess.common.NonNullWrapperCommon;
+import com.dlb.chess.common.model.MoveSpecification;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Outcome of a successful lenient SAN parse: the resolved move, plus the list of deviations the parser forgave to get
+ * there. {@code forgivenItems} is empty when the input was already canonical SAN.
+ */
+@SuppressWarnings("null")
+public record LenientSanParserValidationResult(@NonNull MoveSpecification moveSpecification,
+    @NonNull ImmutableList<@NonNull ForgivenItem> forgivenItems) {
+
+  public LenientSanParserValidationResult {
+    forgivenItems = NonNullWrapperCommon.copyOfList(forgivenItems);
+  }
+}

--- a/src/main/java/com/dlb/chess/san/model/StrictSanParserValidationResult.java
+++ b/src/main/java/com/dlb/chess/san/model/StrictSanParserValidationResult.java
@@ -1,15 +1,13 @@
 package com.dlb.chess.san.model;
 
-import org.eclipse.jdt.annotation.NonNull;
-
 import com.dlb.chess.common.model.MoveSpecification;
 
 /**
  * Outcome of a successful strict SAN parse: the resolved move. Symmetric in shape with
  * {@link LenientSanParserValidationResult} so callers can switch between strict and lenient parsing by changing one
- * method call rather than reshaping result-handling. The strict pipeline never produces forgiven items, so this
- * record carries only the {@link MoveSpecification}.
+ * method call rather than reshaping result-handling. The strict pipeline never produces forgiven items, so this record
+ * carries only the {@link MoveSpecification}.
  */
-public record StrictSanParserValidationResult(@NonNull MoveSpecification moveSpecification) {
+public record StrictSanParserValidationResult(MoveSpecification moveSpecification) {
 
 }

--- a/src/main/java/com/dlb/chess/san/model/StrictSanParserValidationResult.java
+++ b/src/main/java/com/dlb/chess/san/model/StrictSanParserValidationResult.java
@@ -1,0 +1,15 @@
+package com.dlb.chess.san.model;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+import com.dlb.chess.common.model.MoveSpecification;
+
+/**
+ * Outcome of a successful strict SAN parse: the resolved move. Symmetric in shape with
+ * {@link LenientSanParserValidationResult} so callers can switch between strict and lenient parsing by changing one
+ * method call rather than reshaping result-handling. The strict pipeline never produces forgiven items, so this
+ * record carries only the {@link MoveSpecification}.
+ */
+public record StrictSanParserValidationResult(@NonNull MoveSpecification moveSpecification) {
+
+}

--- a/src/main/java/com/dlb/chess/san/package-info.java
+++ b/src/main/java/com/dlb/chess/san/package-info.java
@@ -5,10 +5,14 @@
  * on — see {@link com.dlb.chess.san.enums.SanValidationProblem}).
  *
  * <p>
- * The strict pipeline is the main entry point: {@code SanValidation.validateSan(san, board)} converts a SAN string
- * into a {@link com.dlb.chess.common.model.MoveSpecification}, throwing {@code SanValidationException} on any failure.
- * The same pipeline is reached from both the programmatic {@link com.dlb.chess.board.Board#performMove(String)} and
- * the lenient PGN parser's movetext path — one validation surface, used twice.
+ * Two parser entry points sit on top of a shared validation core:
+ * <ul>
+ * <li>{@link com.dlb.chess.san.validate.StrictSanParser#parseText(String, com.dlb.chess.common.interfaces.ChessBoard)}
+ * — canonical SAN only. Reached from {@link com.dlb.chess.board.Board#moveStrict(String)}.
+ * <li>{@link com.dlb.chess.san.lenient.LenientSanParser#parseText(String, com.dlb.chess.common.interfaces.ChessBoard)}
+ * — accepts a defined set of forgivable deviations from canonical SAN. Reached from
+ * {@link com.dlb.chess.board.Board#moveLenient(String)}. See {@code specification.md} §3.3.1 for the taxonomy.
+ * </ul>
  *
  * <p>
  * Generation goes the other direction: {@link com.dlb.chess.san.MoveToSan} produces canonical SAN for a played move
@@ -17,9 +21,7 @@
  *
  * <p>
  * Format-level checks live in {@link com.dlb.chess.san.validate.format}; movement-level (legal-move, king-safety)
- * checks live in {@link com.dlb.chess.san.validate.movement}. A future lenient-SAN release (see {@code tasks.md})
- * will add tolerance for things the strict pipeline rejects today: long algebraic input, zero-instead-of-O castling,
- * over-specified disambiguation, missing/wrong check suffixes, etc.
+ * checks live in {@link com.dlb.chess.san.validate.movement}.
  */
 @NonNullByDefault
 package com.dlb.chess.san;

--- a/src/main/java/com/dlb/chess/san/validate/SanValidateCheck.java
+++ b/src/main/java/com/dlb/chess/san/validate/SanValidateCheck.java
@@ -63,7 +63,7 @@ public abstract class SanValidateCheck extends AbstractSan {
 
   private static SanTerminalMarker calculateBoardSanTerminalMarker(ChessBoard board,
       MoveSpecification moveSpecification) {
-    board.performMove(moveSpecification);
+    board.move(moveSpecification);
 
     SanTerminalMarker sanTerminalMarker;
     if (board.isCheckmate()) {
@@ -73,7 +73,7 @@ public abstract class SanValidateCheck extends AbstractSan {
     } else {
       sanTerminalMarker = SanTerminalMarker.NONE;
     }
-    board.unperformMove();
+    board.unmove();
 
     return sanTerminalMarker;
   }

--- a/src/main/java/com/dlb/chess/san/validate/StrictSanParser.java
+++ b/src/main/java/com/dlb/chess/san/validate/StrictSanParser.java
@@ -14,12 +14,30 @@ import com.dlb.chess.model.LegalMove;
 import com.dlb.chess.san.AbstractSan;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
+import com.dlb.chess.san.model.StrictSanParserValidationResult;
 import com.dlb.chess.san.validate.format.SanValidateFormat;
 import com.dlb.chess.san.validate.movement.SanValidateMovement;
 
-public class SanValidation extends AbstractSan {
+/**
+ * Public entry point for the strict SAN pipeline. Accepts canonical SAN only; the result is symmetric in shape with
+ * {@link com.dlb.chess.san.lenient.LenientSanParser} so callers can switch between strict and lenient by changing
+ * one method call. Use {@link com.dlb.chess.san.lenient.LenientSanParser} when parsing real-world PGN that may
+ * contain forgivable deviations from canonical SAN.
+ */
+public class StrictSanParser extends AbstractSan {
 
-  public static MoveSpecification validateSan(String san, ChessBoard board) throws SanValidationException {
+  /**
+   * Parses {@code san} as canonical SAN against {@code board} and returns the resolved {@link MoveSpecification}.
+   *
+   * @throws SanValidationException if the input is not canonical SAN, or is canonical but does not represent a legal
+   *         move on the current position
+   */
+  public static StrictSanParserValidationResult parseText(String san, ChessBoard board) throws SanValidationException {
+    final MoveSpecification moveSpecification = parseTextInternal(san, board);
+    return new StrictSanParserValidationResult(moveSpecification);
+  }
+
+  private static MoveSpecification parseTextInternal(String san, ChessBoard board) throws SanValidationException {
     validateGameNotEnded(board);
 
     final var sanParse = SanValidateFormat.validateFormat(san);

--- a/src/main/java/com/dlb/chess/unwinnability/findhelpmate/AbstractFindHelpmate.java
+++ b/src/main/java/com/dlb/chess/unwinnability/findhelpmate/AbstractFindHelpmate.java
@@ -27,7 +27,7 @@ public abstract class AbstractFindHelpmate {
     var isFoundFivefold = false;
     var isFoundSeventyFiveMoves = false;
     for (final LegalMove legalMove : moveProgressList) {
-      boardCheck.performMove(legalMove.moveSpecification());
+      boardCheck.move(legalMove.moveSpecification());
       if (!isFoundFivefold && boardCheck.isFivefoldRepetition()) {
         isFoundFivefold = true;
       }
@@ -62,7 +62,7 @@ public abstract class AbstractFindHelpmate {
     final var boardCheck = new Board(fen);
 
     for (final LegalMove legalMove : moveProgressList) {
-      boardCheck.performMove(legalMove.moveSpecification());
+      boardCheck.move(legalMove.moveSpecification());
     }
     if (!ClassicalCheckmate.isClassicalCheckmatePosition(color, boardCheck.getStaticPosition())) {
       throw new ProgrammingMistakeException("It is not a classical checkmate position");

--- a/src/main/java/com/dlb/chess/unwinnability/findhelpmate/exhaust/FindHelpmateExhaust.java
+++ b/src/main/java/com/dlb/chess/unwinnability/findhelpmate/exhaust/FindHelpmateExhaust.java
@@ -197,7 +197,7 @@ public class FindHelpmateExhaust extends AbstractFindHelpmate {
       }
 
       // 9: if Find-Helpmatec(pos.move(m), depth+1, maxDepth+inc) then return true
-      board.performMove(legalMove.moveSpecification());
+      board.move(legalMove.moveSpecification());
 
       moveEvaluationList.add(legalMove);
 
@@ -207,7 +207,7 @@ public class FindHelpmateExhaust extends AbstractFindHelpmate {
       localNodeCount++;
 
       final var findHelpmate = findHelpmate(board, newDepth, maxDepth, actualDepth + 1, isProgress);
-      board.unperformMove();
+      board.unmove();
       switch (findHelpmate) {
         case TRUE:
           return findHelpmate;

--- a/src/main/java/com/dlb/chess/unwinnability/findhelpmate/interrupt/FindHelpMateInterrupt.java
+++ b/src/main/java/com/dlb/chess/unwinnability/findhelpmate/interrupt/FindHelpMateInterrupt.java
@@ -54,7 +54,7 @@ public class FindHelpMateInterrupt extends AbstractFindHelpmate {
         && !board.isSeventyFiveMove()) {
 
       for (final LegalMove legalMove : board.getLegalMoveSet()) {
-        board.performMove(legalMove.moveSpecification());
+        board.move(legalMove.moveSpecification());
         if (IS_DEBUG) {
           final UciMove uciMove = UciMoveUtility.convertMoveSpecificationToUci(legalMove.havingMove(),
               legalMove.moveSpecification());
@@ -63,7 +63,7 @@ public class FindHelpMateInterrupt extends AbstractFindHelpmate {
 
         mateList.add(legalMove);
         final var hasCheckmate = calculateHelpmate(board, c, currentDepth + 1, mateList);
-        board.unperformMove();
+        board.unmove();
         switch (hasCheckmate) {
           case TRUE -> {
             return FindHelpMateInterruptResult.TRUE;

--- a/src/main/java/com/dlb/chess/unwinnability/full/UnwinnableFullAnalyzer.java
+++ b/src/main/java/com/dlb/chess/unwinnability/full/UnwinnableFullAnalyzer.java
@@ -43,7 +43,7 @@ public class UnwinnableFullAnalyzer {
     while (isForcedMove && !isFivefoldOrSeventyFiveMove) {
       isCanUseMobilitySolution = false;
       final LegalMove onlyLegalMove = NonNullWrapperCommon.getFirst(new ArrayList<>(board.getLegalMoveSet()));
-      board.performMove(onlyLegalMove.moveSpecification());
+      board.move(onlyLegalMove.moveSpecification());
       isForcedMove = board.getLegalMoveSet().size() == 1;
       isFivefoldOrSeventyFiveMove = board.isFivefoldRepetition() || board.isSeventyFiveMove();
       totalForcedMoves++;
@@ -101,7 +101,7 @@ public class UnwinnableFullAnalyzer {
 
   private static void undoForcedMoves(ChessBoard board, int totalForcedMoves) {
     for (var i = 1; i <= totalForcedMoves; i++) {
-      board.unperformMove();
+      board.unmove();
     }
   }
 }

--- a/src/main/java/com/dlb/chess/unwinnability/quick/UnwinnableQuickAnalyzer.java
+++ b/src/main/java/com/dlb/chess/unwinnability/quick/UnwinnableQuickAnalyzer.java
@@ -61,7 +61,7 @@ public class UnwinnableQuickAnalyzer {
       if (isForcedMove) {
         final List<LegalMove> legalMoveList = new ArrayList<>(board.getLegalMoveSet());
         final LegalMove legalMove = NonNullWrapperCommon.getFirst(legalMoveList);
-        board.performMove(legalMove.moveSpecification());
+        board.move(legalMove.moveSpecification());
         isFivefoldOrSeventyFiveMove = board.isFivefoldRepetition() || board.isSeventyFiveMove();
         countHalfmoves++;
       }
@@ -132,7 +132,7 @@ public class UnwinnableQuickAnalyzer {
 
   private static void unperformHalfmoves(ChessBoard board, int countHalfmoves) {
     for (var i = 1; i <= countHalfmoves; i++) {
-      board.unperformMove();
+      board.unmove();
     }
   }
 }

--- a/src/main/java/com/dlb/chess/utility/PgnUtility.java
+++ b/src/main/java/com/dlb/chess/utility/PgnUtility.java
@@ -14,7 +14,7 @@ public abstract class PgnUtility {
   public static Board calculateBoardPerLastMove(PgnFile pgnFile) {
     final Board board = new Board(pgnFile.startFen());
     for (final PgnHalfMove pgnHalfMove : pgnFile.halfMoveList()) {
-      board.performMove(pgnHalfMove.san());
+      board.moveStrict(pgnHalfMove.san());
     }
     return board;
   }

--- a/src/main/resources/com/dlb/chess/messages/messages.properties
+++ b/src/main/resources/com/dlb/chess/messages/messages.properties
@@ -248,6 +248,33 @@ validation.san.checkSymbolButNoCheck=The move is neither check nor checkmate, bu
 validation.san.noSymbolButCheckmate=The move is checkmate, but no symbol was specified.
 validation.san.noSymbolButCheck=The move is check, but no symbol was specified.
 
+#lenient SAN parser - internal failures
+validation.san.lenient.parseFailed=The lenient SAN parser could not parse ''{0}'': {1}
+validation.san.lenient.mixedCastlingZeroAndO=The castling notation ''{0}'' mixes the digit ''0'' with the letter ''O'' - use one or the other, not both.
+
+#lenient SAN parser - forgiven-item descriptions (one per LenientSanValidationProblem)
+validation.san.lenient.missingCheckSuffix=The move is check, but the check symbol (+) is missing.
+validation.san.lenient.missingCheckmateSuffix=The move is checkmate, but the checkmate symbol (#) is missing.
+validation.san.lenient.spuriousCheckSuffix=The move is not check, but a check symbol (+) is present.
+validation.san.lenient.spuriousCheckmateSuffix=The move is not checkmate, but a checkmate symbol (#) is present.
+validation.san.lenient.wrongCheckSuffixForCheckmate=The move is checkmate, but the check symbol (+) was used instead of the checkmate symbol (#).
+validation.san.lenient.wrongCheckmateSuffixForCheck=The move is check only, but the checkmate symbol (#) was used instead of the check symbol (+).
+validation.san.lenient.missingCaptureMarker=The move is a capture, but the capture symbol (x) is missing.
+validation.san.lenient.spuriousCaptureMarker=The move is not a capture, but a capture symbol (x) is present.
+validation.san.lenient.overspecifiedFileDisambiguation=The origin file disambiguation is not necessary - the move is uniquely identified without it.
+validation.san.lenient.overspecifiedRankDisambiguation=The origin rank disambiguation is not necessary - the move is uniquely identified without it.
+validation.san.lenient.overspecifiedSquareDisambiguation=The origin square disambiguation is more specific than necessary.
+validation.san.lenient.nonStandardRankDisambiguation=Disambiguation by rank uniquely identifies the move, but canonical SAN uses file disambiguation when both forms work.
+validation.san.lenient.longAlgebraicNotation=The move is in long algebraic notation - canonical SAN omits the origin square when not required for disambiguation.
+validation.san.lenient.uciNotation=The move is in UCI notation - canonical SAN uses the piece letter and only the disambiguation that is required.
+validation.san.lenient.zeroInsteadOfOCastling=Castling was written with the digit ''0'' - canonical SAN uses the letter ''O'' (O-O or O-O-O).
+validation.san.lenient.explicitPawnLetter=Canonical SAN omits the pawn letter (P) for pawn moves.
+validation.san.lenient.missingPromotionEquals=The promotion symbol ''='' is missing before the promotion piece letter.
+validation.san.lenient.lowercasePieceLetter=The piece letter must be uppercase in canonical SAN.
+validation.san.lenient.uppercaseFileLetter=File letters must be lowercase (a-h) in canonical SAN.
+validation.san.lenient.uppercaseCaptureMarker=The capture symbol must be lowercase ''x'' in canonical SAN.
+validation.san.lenient.lowercasePromotionPiece=The promotion piece letter must be uppercase (R, N, B, or Q) in canonical SAN.
+
 #repetitions
 report.repetition.threefold.ahead.title=Valid threefold claims ahead
 report.repetition.threefold.ahead.none=None

--- a/src/test/java/com/dlb/chess/test/analyze/AbstractTestChessRuleAnalyzerScenarios.java
+++ b/src/test/java/com/dlb/chess/test/analyze/AbstractTestChessRuleAnalyzerScenarios.java
@@ -27,7 +27,7 @@ import com.dlb.chess.exceptions.InvalidMoveException;
  *     {@link ChessRuleAnalyzer#analyzeKingSafety} directly and assert the translated
  *     KingSafetyCheck;</li>
  * <li>spec-coherence and castling MoveChecks ({@code MOVE_SPEC_*}, {@code KING_CASTLING_*}) — fall
- *     back to {@code Board.performMove} and assert the InvalidMoveException's MoveCheck. These are
+ *     back to {@code Board.move} and assert the InvalidMoveException's MoveCheck. These are
  *     not in analyzer territory.</li>
  * </ul>
  *
@@ -59,7 +59,7 @@ public abstract class AbstractTestChessRuleAnalyzerScenarios implements EnumCons
     // fallback: spec-coherence or castling — exercise via the surface
     var isException = false;
     try {
-      board.performMove(move);
+      board.move(move);
     } catch (final InvalidMoveException e) {
       isException = true;
       assertEquals(expectedMoveCheck, e.getMoveCheck());

--- a/src/test/java/com/dlb/chess/test/analyze/TestChessRuleAnalyzerScenarios.java
+++ b/src/test/java/com/dlb/chess/test/analyze/TestChessRuleAnalyzerScenarios.java
@@ -34,10 +34,10 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVE_SPEC_FROM_SQUARE_OCCUPIED_BY_OPPONENT);
 
     move = new MoveSpecification(B2, B3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B7, B6);
-    board.performMove(move);
+    board.move(move);
 
     // rook movement
     move = new MoveSpecification(A1, B2);
@@ -60,20 +60,20 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_NOT_POSSIBLE);
 
     move = new MoveSpecification(C2, C4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C7, C5);
-    board.performMove(move);
+    board.move(move);
 
     // knight movement
     move = new MoveSpecification(B1, C2);
     check(board, move, MoveCheck.MOVEMENT_NOT_POSSIBLE);
 
     move = new MoveSpecification(B1, C3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B8, C6);
-    board.performMove(move);
+    board.move(move);
 
     // bishop movement
     move = new MoveSpecification(C1, C2);
@@ -100,10 +100,10 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_NOT_POSSIBLE);
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     // king movement
     move = new MoveSpecification(E1, E3);
@@ -158,10 +158,10 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_TO_SQUARE_OCCUPIED_BY_OWN_PIECE);
 
     move = new MoveSpecification(A2, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B1, A3);
     check(board, move, MoveCheck.MOVEMENT_TO_SQUARE_OCCUPIED_BY_OWN_PIECE);
@@ -171,16 +171,16 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_TO_SQUARE_OCCUPIED_BY_OWN_PIECE);
 
     move = new MoveSpecification(D2, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D1, D2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C1, D2);
     check(board, move, MoveCheck.MOVEMENT_TO_SQUARE_OCCUPIED_BY_OWN_PIECE);
@@ -213,85 +213,85 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
 
     // pawn
     MoveSpecification move = new MoveSpecification(A3, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A7, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B2, B4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B4, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A4, A5);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_ONE_SQUARE_TO_SQUARE_NOT_EMPTY_OWN_PIECE);
 
     move = new MoveSpecification(D4, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E4, E5);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_ONE_SQUARE_TO_SQUARE_NOT_EMPTY_OWN_PIECE);
 
     move = new MoveSpecification(H2, H4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H7, H5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H4, H5);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_ONE_SQUARE_TO_SQUARE_NOT_EMPTY_OPPONENT_PIECE);
 
     move = new MoveSpecification(A5, A6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B7, A6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A4, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A5, A6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_ONE_SQUARE_TO_SQUARE_NOT_EMPTY_OPPONENT_PIECE);
 
     move = new MoveSpecification(F2, F3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F3, E4);
     check(board, move, MoveCheck.MOVEMENT_PAWN_DIAGONAL_OWN_PIECE);
 
     move = new MoveSpecification(C2, C3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F8, B4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C3, B4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B4, A5);
     check(board, move, MoveCheck.MOVEMENT_PAWN_DIAGONAL_OWN_PIECE);
@@ -309,43 +309,43 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_WRONG_RANK);
 
     move = new MoveSpecification(F3, F4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F4, F5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F5, E6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
 
     move = new MoveSpecification(D2, H6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H6, H5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H5, H7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H4, H5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F5, E6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
@@ -366,67 +366,67 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E4, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D6, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E5, D6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
 
     move = new MoveSpecification(H2, H4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G7, G6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H4, H5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G6, G5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E1, E2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H5, G6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
 
     move = new MoveSpecification(A2, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B7, B6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A4, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B6, B5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A5, B6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
 
     move = new MoveSpecification(D1, E1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F7, F6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E1, D1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F6, F5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E5, F6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
@@ -435,43 +435,43 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(B2, B4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C7, C5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B4, B5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A7, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B5, C6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
 
     move = new MoveSpecification(B5, A6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, C7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H2, H4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C7, D8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H4, H5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G7, G5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H5, G6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
@@ -486,40 +486,40 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     final ChessBoard board = new Board();
 
     MoveSpecification move = new MoveSpecification(B1, C3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B8, C6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C2, C4);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_TWO_SQUARE_JUMP_OVER_SQUARE_ONLY_NOT_EMPTY);
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F1, C4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F8, C5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C3, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C6, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C2, C4);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_TWO_SQUARE_TO_SQUARE_ONLY_NOT_EMPTY);
 
     move = new MoveSpecification(A4, C3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A5, C6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C2, C4);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_TWO_SQUARE_BOTH_SQUARE_NOT_EMPTY);
@@ -535,88 +535,88 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     MoveSpecification move = new MoveSpecification(B1, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B8, C6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A3, B1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C6, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B1, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G8, F6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A3, B1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F6, H5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B1, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H5, F4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A3, B1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D4, E2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E1, E2);
     check(board, move, MoveCheck.KING_CAPTURES_GUARDED_PIECE);
 
     move = new MoveSpecification(D2, D3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F4, H3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B1, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A3, B1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F8, C5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B1, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C5, F2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E1, F2);
     check(board, move, MoveCheck.KING_CAPTURES_GUARDED_PIECE);
 
     move = new MoveSpecification(E1, D2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, H4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A3, B1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H4, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B1, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D4, G4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D2, E2);
     check(board, move, MoveCheck.KING_CAPTURES_GUARDED_PIECE);
@@ -625,64 +625,64 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E1, E2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E8, E7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E2, E3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G1, F3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G8, H6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F3, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H6, G8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E3, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G8, H6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D4, D5);
     check(board, move, MoveCheck.KING_MOVES_NEXT_TO_OPPONENT_KING);
 
     move = new MoveSpecification(E5, F3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H6, G8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D4, E5);
     check(board, move, MoveCheck.KING_MOVES_NEXT_TO_OPPONENT_KING);
 
     move = new MoveSpecification(D4, C4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G8, E7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C4, C5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H7, H6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C5, D6);
     check(board, move, MoveCheck.KING_MOVES_NEXT_TO_OPPONENT_KING);
@@ -698,22 +698,22 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     MoveSpecification move = new MoveSpecification(A2, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A7, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D2, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     // rook
     move = new MoveSpecification(A1, A2, PromotionPieceType.QUEEN);
@@ -749,42 +749,42 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E4, D5, PromotionPieceType.KNIGHT);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
 
     move = new MoveSpecification(E4, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C7, C5);
-    board.performMove(move);
+    board.move(move);
 
     // en passant capture
     move = new MoveSpecification(D5, C6, PromotionPieceType.BISHOP);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
 
     move = new MoveSpecification(D5, C6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H7, H6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C6, B7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H6, H5);
-    board.performMove(move);
+    board.move(move);
 
     // promotion with capture
     move = new MoveSpecification(B7, A8);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_PROMOTION_NO_PROMOTION_PIECE);
 
     move = new MoveSpecification(B7, A8, PromotionPieceType.ROOK);
-    board.performMove(move);
+    board.move(move);
 
     // pawn move - promotion piece checks with promotion without capture
     board = new Board();
@@ -796,41 +796,41 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
 
     move = new MoveSpecification(D2, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D4, E5, PromotionPieceType.QUEEN);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
 
     move = new MoveSpecification(D4, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F7, F5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E5, F6, PromotionPieceType.ROOK);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
 
     move = new MoveSpecification(E5, F6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G8, H6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F6, G7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A7, A6);
-    board.performMove(move);
+    board.move(move);
 
     // promotion without capture
     move = new MoveSpecification(G7, G8);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_PROMOTION_NO_PROMOTION_PIECE);
 
     move = new MoveSpecification(G7, G8, PromotionPieceType.QUEEN);
-    board.performMove(move);
+    board.move(move);
 
   }
 
@@ -839,7 +839,7 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
   void testBlackMovingPieces() {
     final ChessBoard board = new Board();
 
-    board.performMove("e4");
+    board.moveStrict("e4");
 
     MoveSpecification move = new MoveSpecification(E6, E5);
     check(board, move, MoveCheck.MOVE_SPEC_FROM_SQUARE_EMPTY);
@@ -860,10 +860,10 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVE_SPEC_FROM_SQUARE_OCCUPIED_BY_OPPONENT);
 
     move = new MoveSpecification(B7, B6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B2, B3);
-    board.performMove(move);
+    board.move(move);
 
     // rook movement
     move = new MoveSpecification(A8, B7);
@@ -886,20 +886,20 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_NOT_POSSIBLE);
 
     move = new MoveSpecification(C7, C5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C2, C4);
-    board.performMove(move);
+    board.move(move);
 
     // knight movement
     move = new MoveSpecification(B8, C7);
     check(board, move, MoveCheck.MOVEMENT_NOT_POSSIBLE);
 
     move = new MoveSpecification(B8, C6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B1, C3);
-    board.performMove(move);
+    board.move(move);
 
     // bishop movement
     move = new MoveSpecification(C8, C7);
@@ -926,10 +926,10 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_NOT_POSSIBLE);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D2, D4);
-    board.performMove(move);
+    board.move(move);
 
     // king movement
     move = new MoveSpecification(E8, E6);
@@ -971,7 +971,7 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
 
     // capturing own pieces
     final ChessBoard board = new Board();
-    board.performMove("e4");
+    board.moveStrict("e4");
 
     // rook
     MoveSpecification move = new MoveSpecification(A8, A7);
@@ -985,10 +985,10 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_TO_SQUARE_OCCUPIED_BY_OWN_PIECE);
 
     move = new MoveSpecification(A7, A6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A2, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B8, A6);
     check(board, move, MoveCheck.MOVEMENT_TO_SQUARE_OCCUPIED_BY_OWN_PIECE);
@@ -998,16 +998,16 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_TO_SQUARE_OCCUPIED_BY_OWN_PIECE);
 
     move = new MoveSpecification(D7, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D2, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D1, D2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C8, D7);
     check(board, move, MoveCheck.MOVEMENT_TO_SQUARE_OCCUPIED_BY_OWN_PIECE);
@@ -1040,34 +1040,34 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     ChessBoard board = new Board();
 
     MoveSpecification move = new MoveSpecification(A2, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B7, B5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A3, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B5, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A1, A2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A7, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A2, A1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A5, A4);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_ONE_SQUARE_TO_SQUARE_NOT_EMPTY_OWN_PIECE);
 
     move = new MoveSpecification(G8, H6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A1, A2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H7, H6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_ONE_SQUARE_TO_SQUARE_NOT_EMPTY_OWN_PIECE);
@@ -1075,28 +1075,28 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(A2, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A7, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A1, A3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A5, A4);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_ONE_SQUARE_TO_SQUARE_NOT_EMPTY_OPPONENT_PIECE);
 
     move = new MoveSpecification(A8, A6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A3, G3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A6, A7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G3, G6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G7, G6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_ONE_SQUARE_TO_SQUARE_NOT_EMPTY_OPPONENT_PIECE);
@@ -1104,40 +1104,40 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B8, C6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D2, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B7, C6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_DIAGONAL_OWN_PIECE);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G2, G4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G4, G5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G5, G6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H7, G6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E1, E2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F7, G6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_DIAGONAL_OWN_PIECE);
@@ -1145,7 +1145,7 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G7, F6);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_WRONG_RANK);
@@ -1154,19 +1154,19 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_WRONG_RANK);
 
     move = new MoveSpecification(F7, F5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E4, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F5, E4);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_WRONG_RANK);
 
     move = new MoveSpecification(B7, B6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G2, G4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B6, C5);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_WRONG_RANK);
@@ -1177,19 +1177,19 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(A2, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B7, B5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C2, C4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B5, B4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B4, A3);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
@@ -1198,43 +1198,43 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
 
     move = new MoveSpecification(C8, B7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A1, A2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H7, H5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A2, A1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H5, H4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A1, A2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H4, G3);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
 
     move = new MoveSpecification(F7, F5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A2, A1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F5, F4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G2, G4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B8, C6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A1, A2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F4, G3);
     check(board, move, MoveCheck.MOVEMENT_PAWN_EN_PASSANT_NO_IMMEDIATE_BEFORE_TWO_SQUARE_ADVANCE);
@@ -1248,64 +1248,64 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     final ChessBoard board = new Board();
 
     MoveSpecification move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B8, C6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D2, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C7, C5);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_TWO_SQUARE_JUMP_OVER_SQUARE_ONLY_NOT_EMPTY);
 
     move = new MoveSpecification(C6, B8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A2, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B8, C6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A4, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C6, B8);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A5, A6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A7, A5);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_TWO_SQUARE_JUMP_OVER_SQUARE_ONLY_NOT_EMPTY);
 
     move = new MoveSpecification(G8, F6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A1, A2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F6, H5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A2, A1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H7, H5);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_TWO_SQUARE_TO_SQUARE_ONLY_NOT_EMPTY);
 
     move = new MoveSpecification(H5, F6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F2, F4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(H7, H6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F4, F5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F7, F5);
     check(board, move, MoveCheck.MOVEMENT_PAWN_FORWARD_TWO_SQUARE_BOTH_SQUARE_NOT_EMPTY);
@@ -1319,25 +1319,25 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     ChessBoard board = new Board();
 
     MoveSpecification move = new MoveSpecification(B1, C3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C3, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E8, D7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C2, C4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G1, F3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D6, D5);
     check(board, move, MoveCheck.KING_CAPTURES_GUARDED_PIECE);
@@ -1346,25 +1346,25 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(F2, F3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F7, F6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E1, F2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E8, F7);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F2, E3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(F7, E6);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E3, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E6, E5);
     check(board, move, MoveCheck.KING_MOVES_NEXT_TO_OPPONENT_KING);
@@ -1377,25 +1377,25 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     ChessBoard board = new Board();
 
     MoveSpecification move = new MoveSpecification(A2, A4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A7, A5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D2, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D1, D2);
-    board.performMove(move);
+    board.move(move);
 
     // rook
     move = new MoveSpecification(A8, A7, PromotionPieceType.QUEEN);
@@ -1425,7 +1425,7 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E7, E6, PromotionPieceType.QUEEN);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
@@ -1434,10 +1434,10 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
 
     move = new MoveSpecification(E7, E5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D2, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E5, D4, PromotionPieceType.KNIGHT);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
@@ -1446,19 +1446,19 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(B1, C3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C3, B1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D5, D4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(E2, E4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D4, E3, PromotionPieceType.BISHOP);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);
@@ -1467,31 +1467,31 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(B1, C3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B7, B5);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C3, B1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B5, B4);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B1, C3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B4, B3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(C3, B1);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(B3, A2);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(G1, F3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(A2, B1);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_PROMOTION_NO_PROMOTION_PIECE);
@@ -1500,7 +1500,7 @@ class TestChessRuleAnalyzerScenarios extends AbstractTestChessRuleAnalyzerScenar
     board = new Board();
 
     move = new MoveSpecification(G1, F3);
-    board.performMove(move);
+    board.move(move);
 
     move = new MoveSpecification(D7, D6, PromotionPieceType.QUEEN);
     check(board, move, MoveCheck.MOVE_SPEC_PAWN_NON_PROMOTION_PROMOTION_PIECE);

--- a/src/test/java/com/dlb/chess/test/board/TestBoardUnperformMove.java
+++ b/src/test/java/com/dlb/chess/test/board/TestBoardUnperformMove.java
@@ -93,13 +93,13 @@ class TestBoardUnperformMove {
       final String san = halfMove.san();
 
       // Test: perform then unperform on actual; it must return to the pre-move state.
-      actual.performMove(san);
-      actual.unperformMove();
+      actual.moveStrict(san);
+      actual.unmove();
       assertBoardsEqual(expected, actual, testCase.pgnFileName(), halfMoveIndex, san);
 
       // Advance both boards by the (now-unperformed) move so the next iteration starts in lockstep.
-      expected.performMove(san);
-      actual.performMove(san);
+      expected.moveStrict(san);
+      actual.moveStrict(san);
     }
     return halfMoveIndex;
   }

--- a/src/test/java/com/dlb/chess/test/board/TestEnPassantRole.java
+++ b/src/test/java/com/dlb/chess/test/board/TestEnPassantRole.java
@@ -53,7 +53,7 @@ class TestEnPassantRole {
   void testEnPassantCaptureAfterTwoSquareAdvance() {
     // Classic en-passant setup: 1.e4 Nf6 2.e5 d5 — now white's e5 pawn can capture d-pawn en passant.
     final Board board = new Board();
-    board.performMoves("e4", "Nf6", "e5", "d5");
+    board.movesStrict("e4", "Nf6", "e5", "d5");
     final LegalMove exd6 = findLegalMoveByFromTo(board, Square.E5, Square.D6);
     assertEquals(EnPassantRole.EN_PASSANT_CAPTURE, exd6.enPassantRole());
     assertTrue(exd6.enPassantRole().isEnPassantCapture());
@@ -64,7 +64,7 @@ class TestEnPassantRole {
   void testNoneForRegularPawnCapture() {
     // Plain diagonal pawn capture (not en passant).
     final Board board = new Board();
-    board.performMoves("e4", "d5");
+    board.movesStrict("e4", "d5");
     // Now 2.exd5 is a regular capture, not en passant.
     final LegalMove exd5 = findLegalMoveByFromTo(board, Square.E4, Square.D5);
     assertEquals(EnPassantRole.NONE, exd5.enPassantRole());

--- a/src/test/java/com/dlb/chess/test/board/TestPerformMoveSanContract.java
+++ b/src/test/java/com/dlb/chess/test/board/TestPerformMoveSanContract.java
@@ -11,7 +11,7 @@ import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.common.model.MoveSpecification;
 import com.dlb.chess.model.PgnHalfMove;
 import com.dlb.chess.pgn.parser.model.PgnFile;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 import com.dlb.chess.test.model.PgnFileTestCase;
 import com.dlb.chess.test.model.PgnFileTestCaseList;
 import com.dlb.chess.test.pgn.parser.PgnCacheForStrictPgnParserTestCases;
@@ -19,7 +19,7 @@ import com.dlb.chess.test.pgntest.PgnExpectedValue;
 
 /**
  * Verifies the SAN ↔ MoveSpecification consistency that {@link com.dlb.chess.board.Board#performMove(String)
- * Board.performMove(String)} relies on: once {@link SanValidation#validateSan SanValidation.validateSan} has produced a
+ * Board.moveStrict(String)} relies on: once {@link SanValidation#validateSan SanValidation.validateSan} has produced a
  * MoveSpecification from a SAN, that MoveSpec is the canonical representation of the move and round-trips both ways.
  * The board therefore performs the move with no further re-validation of the spec.
  *
@@ -27,7 +27,7 @@ import com.dlb.chess.test.pgntest.PgnExpectedValue;
  *
  * <p>
  * For each halfmove of each PGN: derive the MoveSpec via {@code validateSan(san, board)} <em>before</em> performing,
- * then perform via {@code board.performMove(san)} and assert:
+ * then perform via {@code board.moveStrict(san)} and assert:
  *
  * <ol>
  * <li>the derived MoveSpec equals the legal move that was actually played
@@ -91,10 +91,10 @@ class TestPerformMoveSanContract {
       final var hmi = halfMoveIndex;
       final String expectedProvidedSan = halfMove.san();
 
-      final MoveSpecification expectedCalculatedMoveSpecification = SanValidation.validateSan(expectedProvidedSan,
-          board);
+      final MoveSpecification expectedCalculatedMoveSpecification = StrictSanParser
+          .parseText(expectedProvidedSan, board).moveSpecification();
 
-      board.performMove(expectedProvidedSan);
+      board.moveStrict(expectedProvidedSan);
 
       final MoveSpecification actualStoredMoveSpecification = board.getLastMove().moveSpecification();
       assertEquals(expectedCalculatedMoveSpecification, actualStoredMoveSpecification,
@@ -118,13 +118,13 @@ class TestPerformMoveSanContract {
     final ChessBoard board = new Board(pgnFile.startFen());
 
     for (final PgnHalfMove halfMove : pgnFile.halfMoveList()) {
-      board.performMove(halfMove.san());
+      board.moveStrict(halfMove.san());
       final MoveSpecification expectedStoredMoveSpecification = board.getLastMove().moveSpecification();
       final String calculatedSan = board.getSan();
-      board.unperformMove();
-      final MoveSpecification actualCalculatedMoveSpecification = SanValidation.validateSan(calculatedSan, board);
+      board.unmove();
+      final MoveSpecification actualCalculatedMoveSpecification = StrictSanParser.parseText(calculatedSan, board).moveSpecification();
       assertEquals(expectedStoredMoveSpecification, actualCalculatedMoveSpecification);
-      board.performMove(halfMove.san());
+      board.moveStrict(halfMove.san());
     }
   }
 

--- a/src/test/java/com/dlb/chess/test/board/TestStaticPosition.java
+++ b/src/test/java/com/dlb/chess/test/board/TestStaticPosition.java
@@ -34,7 +34,7 @@ class TestStaticPosition {
 
     final Board board = new Board();
 
-    board.performMoves("e4", "e5", "Bc4", "Bc5", "Nf3", "Nc6");
+    board.movesStrict("e4", "e5", "Bc4", "Bc5", "Nf3", "Nc6");
 
     final var expected = """
         r.bqk.nr

--- a/src/test/java/com/dlb/chess/test/common/utility/TestFileUtility.java
+++ b/src/test/java/com/dlb/chess/test/common/utility/TestFileUtility.java
@@ -62,7 +62,8 @@ public class TestFileUtility {
   void testWriteFileThrowsWhenParentFolderDoesNotExist(@TempDir Path tempFolder) {
     final Path filePath = NonNullWrapperCommon.pathResolve(tempFolder, "missing/output.txt");
 
-    final var exception = assertThrows(FileSystemAccessException.class, () -> FileUtility.writeFile(filePath, "text"));
+    @SuppressWarnings("null") final var exception = assertThrows(FileSystemAccessException.class,
+        () -> FileUtility.writeFile(filePath, "text"));
 
     assertTrue(exception.getCause() instanceof IOException);
   }

--- a/src/test/java/com/dlb/chess/test/common/utility/TestNoProgressMoveUtility.java
+++ b/src/test/java/com/dlb/chess/test/common/utility/TestNoProgressMoveUtility.java
@@ -22,7 +22,7 @@ class TestNoProgressMoveUtility {
     final var fenRookEndGame = "8/5k2/4rP2/8/8/8/8/6KR b - - 0 100";
     final Board board = new Board(fenRookEndGame);
 
-    board.performMoves("Kxf6", "Rh2", "Ke7", "Rh3", "Kd6", "Rh4", "Kc6", "Rh5", "Kd6", "Rh6", "Kc6", "Rh7", "Kd6",
+    board.movesStrict("Kxf6", "Rh2", "Ke7", "Rh3", "Kd6", "Rh4", "Kc6", "Rh5", "Kd6", "Rh6", "Kc6", "Rh7", "Kd6",
         "Rh8", "Kc6", "Rg8", "Kd6", "Rg7", "Kc6", "Rg6", "Kd6", "Rg5", "Kc6", "Rg4", "Kd6", "Rg3", "Kc6", "Rg2", "Kd6",
         "Rf2", "Kc6", "Rf3", "Kd6", "Rf4", "Kc6", "Rf5", "Kd6", "Rf6", "Kc6", "Rf7", "Kd6", "Rf8", "Kc6", "Kf1", "Kd6",
         "Rf7", "Kc6", "Rf6", "Kd6", "Rf5", "Kc6", "Rf4", "Kd6", "Rf3", "Kc6", "Rf2", "Kd6", "Rg2", "Kc6", "Rg3", "Kd6",
@@ -36,13 +36,13 @@ class TestNoProgressMoveUtility {
     final List<List<NoProgressHalfMove>> expectedListList = new ArrayList<>();
 
     final Board boardPlayAlong = new Board(fenRookEndGame);
-    boardPlayAlong.performMoves("Kxf6", "Rh2");
+    boardPlayAlong.movesStrict("Kxf6", "Rh2");
 
     final List<NoProgressHalfMove> noProgressHalfMoveList = new ArrayList<>();
     final NoProgressHalfMove firstNoProgressHalfMove = calculateNoProgressHalfMoveForLastMove(boardPlayAlong);
     noProgressHalfMoveList.add(firstNoProgressHalfMove);
 
-    boardPlayAlong.performMoves("Ke7", "Rh3", "Kd6", "Rh4", "Kc6", "Rh5", "Kd6", "Rh6", "Kc6", "Rh7", "Kd6", "Rh8",
+    boardPlayAlong.movesStrict("Ke7", "Rh3", "Kd6", "Rh4", "Kc6", "Rh5", "Kd6", "Rh6", "Kc6", "Rh7", "Kd6", "Rh8",
         "Kc6", "Rg8", "Kd6", "Rg7", "Kc6", "Rg6", "Kd6", "Rg5", "Kc6", "Rg4", "Kd6", "Rg3", "Kc6", "Rg2", "Kd6", "Rf2",
         "Kc6", "Rf3", "Kd6", "Rf4", "Kc6", "Rf5", "Kd6", "Rf6", "Kc6", "Rf7", "Kd6", "Rf8", "Kc6", "Kf1", "Kd6", "Rf7",
         "Kc6", "Rf6", "Kd6", "Rf5", "Kc6", "Rf4", "Kd6", "Rf3", "Kc6", "Rf2", "Kd6", "Rg2", "Kc6", "Rg3", "Kd6", "Rg4",

--- a/src/test/java/com/dlb/chess/test/common/utility/TestPawnWallUtility.java
+++ b/src/test/java/com/dlb/chess/test/common/utility/TestPawnWallUtility.java
@@ -138,9 +138,9 @@ class TestPawnWallUtility extends PawnWall {
       final ChessBoard board = new Board("4k3/8/8/8/p7/8/1P6/4K3 w - - 0 50");
 
       assertTrue(PawnWall.calculateIsAllPawnsCannotCapture(board));
-      board.performMove("b4");
+      board.moveStrict("b4");
       assertFalse(PawnWall.calculateIsAllPawnsCannotCapture(board));
-      board.performMove("Ke7");
+      board.moveStrict("Ke7");
       assertTrue(PawnWall.calculateIsAllPawnsCannotCapture(board));
     }
 
@@ -148,9 +148,9 @@ class TestPawnWallUtility extends PawnWall {
       final ChessBoard board = new Board("8/5p2/3k4/6P1/8/8/8/4K3 b - - 0 50");
 
       assertTrue(PawnWall.calculateIsAllPawnsCannotCapture(board));
-      board.performMove("f5");
+      board.moveStrict("f5");
       assertFalse(PawnWall.calculateIsAllPawnsCannotCapture(board));
-      board.performMove("Ke2");
+      board.moveStrict("Ke2");
       assertTrue(PawnWall.calculateIsAllPawnsCannotCapture(board));
     }
 

--- a/src/test/java/com/dlb/chess/test/common/utility/TestThreefoldClaimAheadUtility.java
+++ b/src/test/java/com/dlb/chess/test/common/utility/TestThreefoldClaimAheadUtility.java
@@ -66,9 +66,9 @@ class TestThreefoldClaimAheadUtility {
 
       final List<ClaimAhead> claimAheadList = new ArrayList<>();
 
-      board.performMove("Nf3");
+      board.moveStrict("Nf3");
       addLastMove(board, claimAheadList);
-      board.unperformMove();
+      board.unmove();
 
       final List<List<ClaimAhead>> expectedListList = new ArrayList<>();
       expectedListList.add(claimAheadList);
@@ -85,9 +85,9 @@ class TestThreefoldClaimAheadUtility {
 
       final List<ClaimAhead> claimAheadList = new ArrayList<>();
 
-      board.performMove("Nb8");
+      board.moveStrict("Nb8");
       addLastMove(board, claimAheadList);
-      board.unperformMove();
+      board.unmove();
 
       final List<List<ClaimAhead>> expectedListList = new ArrayList<>();
       expectedListList.add(claimAheadList);
@@ -111,10 +111,10 @@ class TestThreefoldClaimAheadUtility {
       }
 
       {
-        board.performMove("Nf3");
+        board.moveStrict("Nf3");
         final List<ClaimAhead> claimAheadList = new ArrayList<>();
         addLastMove(board, claimAheadList);
-        board.unperformMove();
+        board.unmove();
 
         expectedListList.add(claimAheadList);
       }
@@ -138,10 +138,10 @@ class TestThreefoldClaimAheadUtility {
       }
 
       {
-        board.performMove("Nc6");
+        board.moveStrict("Nc6");
         final List<ClaimAhead> claimAheadList = new ArrayList<>();
         addLastMove(board, claimAheadList);
-        board.unperformMove();
+        board.unmove();
         expectedListList.add(claimAheadList);
       }
 

--- a/src/test/java/com/dlb/chess/test/common/utility/TestUciMoveUtility.java
+++ b/src/test/java/com/dlb/chess/test/common/utility/TestUciMoveUtility.java
@@ -90,7 +90,7 @@ class TestUciMoveUtility {
     final ChessBoard board = new Board();
 
     for (final UciMoveTest test : list) {
-      board.performMove(test.san());
+      board.moveStrict(test.san());
       final LegalMove lastMove = board.getLastMove();
       final MoveSpecification moveSpecification = lastMove.moveSpecification();
 
@@ -116,7 +116,7 @@ class TestUciMoveUtility {
       final UciMove moveModel = UciMoveValidationUtility.lookup(test.uciMoveStr());
       final MoveSpecification moveSpecificationActual = UciMoveUtility.convertUciMoveToMoveSpecification(board,
           moveModel);
-      board.performMove(test.san());
+      board.moveStrict(test.san());
 
       final MoveSpecification moveSpecificationExpected = board.getLastMove().moveSpecification();
       assertEquals(moveSpecificationExpected, moveSpecificationActual);
@@ -130,7 +130,7 @@ class TestUciMoveUtility {
       final UciMove uciMove = UciMoveValidationUtility.lookup(test.uciMoveStr());
       final String san = UciMoveUtility.convertUciMoveToSan(board, uciMove);
       assertEquals(test.san(), san);
-      board.performMove(test.san());
+      board.moveStrict(test.san());
     }
   }
 

--- a/src/test/java/com/dlb/chess/test/custom/AbstractTestFenParser.java
+++ b/src/test/java/com/dlb/chess/test/custom/AbstractTestFenParser.java
@@ -19,7 +19,7 @@ public abstract class AbstractTestFenParser implements EnumConstants {
 
     for (var i = 0; i < moveList.size(); i++) {
       final MoveSpecification move = NonNullWrapperCommon.get(moveList, i);
-      boardPlayMoves.performMove(move);
+      boardPlayMoves.move(move);
       final String boardFen = boardPlayMoves.getFen();
       final ChessBoard boardFromFen = new Board(boardFen);
 
@@ -32,7 +32,7 @@ public abstract class AbstractTestFenParser implements EnumConstants {
         for (var j = 0; j < boardCreatedFromFenList.size() - 1; j++) {
           @SuppressWarnings("null") final ChessBoard boardFromFenCurrent = boardCreatedFromFenList.get(j);
           final MoveSpecification moveReplay = NonNullWrapperCommon.get(moveList, i);
-          boardFromFenCurrent.performMove(moveReplay);
+          boardFromFenCurrent.move(moveReplay);
           CommonTestUtility.checkBoardsAgainstEachOtherExcludeHistory(boardPlayMoves, boardFromFenCurrent);
         }
       }

--- a/src/test/java/com/dlb/chess/test/custom/TestAttackedSquaresByPlaying.java
+++ b/src/test/java/com/dlb/chess/test/custom/TestAttackedSquaresByPlaying.java
@@ -78,7 +78,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     // black
     {
       final MoveSpecification move = new MoveSpecification(A2, A4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -96,7 +96,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H7, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -114,7 +114,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(A1, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -132,7 +132,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H5, H4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -150,7 +150,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(A3, D3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -169,7 +169,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H8, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -188,7 +188,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D3, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -207,7 +207,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H5, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -225,7 +225,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E2, E3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -243,7 +243,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -261,7 +261,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D1, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -279,7 +279,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(C6, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -297,7 +297,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(F1, B5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -315,7 +315,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D4, F5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -334,7 +334,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // waiting move
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -353,7 +353,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black checks
       final MoveSpecification move = new MoveSpecification(E5, E3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -372,7 +372,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white blocks check with knight
       final MoveSpecification move = new MoveSpecification(G1, E2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -428,7 +428,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     // black
     {
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -446,7 +446,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(G8, H6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -464,7 +464,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(C3, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -482,7 +482,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H6, G4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -500,7 +500,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(C2, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -518,7 +518,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H7, H6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -536,7 +536,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H2, H4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -554,7 +554,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E7, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -572,7 +572,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H1, H2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -590,7 +590,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D8, E7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -609,7 +609,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white checks
       final MoveSpecification move = new MoveSpecification(D5, F6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -628,7 +628,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black moves out of check
       final MoveSpecification move = new MoveSpecification(E8, D8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -646,7 +646,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -664,7 +664,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E7, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -682,7 +682,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(F1, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -700,7 +700,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D6, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -718,7 +718,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E1, F1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -737,7 +737,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black checks
       final MoveSpecification move = new MoveSpecification(G4, H2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -756,7 +756,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white moves out of check
       final MoveSpecification move = new MoveSpecification(F1, E2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -826,7 +826,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     // now we are making moves
     {
       final MoveSpecification move = new MoveSpecification(B2, B3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -844,7 +844,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E7, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -862,7 +862,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(C1, B2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -880,7 +880,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(F8, C5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -898,7 +898,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(B2, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -916,7 +916,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(G7, G6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -935,7 +935,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // capture the rook with white's bishop so black bishop can later check
       final MoveSpecification move = new MoveSpecification(D4, H8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -954,7 +954,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black retreats bishop as waiting move so can free a square for white king
       final MoveSpecification move = new MoveSpecification(C5, B6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -974,7 +974,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white prepares development of light square bishop so can check later
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -994,7 +994,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
       // we need another waiting move for black for prepare square so white king can
       // move out of check, we give retreat square
       final MoveSpecification move = new MoveSpecification(A7, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1013,7 +1013,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // free the square for white king
       final MoveSpecification move = new MoveSpecification(D1, C1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1032,7 +1032,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black checks
       final MoveSpecification move = new MoveSpecification(B6, F2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1051,7 +1051,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white moves out of check
       final MoveSpecification move = new MoveSpecification(E1, D1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopAttackedSquares
@@ -1069,7 +1069,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black takes the knight
       final MoveSpecification move = new MoveSpecification(F2, G1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopAttackedSquares
@@ -1087,7 +1087,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white takes out the bishop for later check
       final MoveSpecification move = new MoveSpecification(F1, C4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopAttackedSquares
@@ -1105,7 +1105,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black moves pawn so white bishop can check
       final MoveSpecification move = new MoveSpecification(E6, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopAttackedSquares
@@ -1123,7 +1123,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white checks
       final MoveSpecification move = new MoveSpecification(C4, F7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopAttackedSquares
@@ -1141,7 +1141,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black moves out of check
       final MoveSpecification move = new MoveSpecification(E8, F8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopAttackedSquares
@@ -1196,7 +1196,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // e4
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1214,7 +1214,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // d5
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1232,7 +1232,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white queen enters the game
       final MoveSpecification move = new MoveSpecification(D1, H5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1251,7 +1251,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // take away one square from white queen by black piece
       final MoveSpecification move = new MoveSpecification(G8, H6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1270,7 +1270,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // take away one more square from white queen by white piece
       final MoveSpecification move = new MoveSpecification(G1, H3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1289,7 +1289,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // a black dummy move, not changing anything
       final MoveSpecification move = new MoveSpecification(H8, G8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1308,7 +1308,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white queen goes for d5
       final MoveSpecification move = new MoveSpecification(H5, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1327,7 +1327,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black queen comes out
       final MoveSpecification move = new MoveSpecification(D8, D6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1347,7 +1347,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white checks
       final MoveSpecification move = new MoveSpecification(D5, F7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1367,7 +1367,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black moves out of check
       final MoveSpecification move = new MoveSpecification(E8, D8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1387,7 +1387,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white moves out bishop to later take away a few squares from black queen
       final MoveSpecification move = new MoveSpecification(F1, B5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1407,7 +1407,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black makes a dummy move
       final MoveSpecification move = new MoveSpecification(G8, H8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1427,7 +1427,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white takes away two squares from black queen
       final MoveSpecification move = new MoveSpecification(B5, C6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1447,7 +1447,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black checks
       final MoveSpecification move = new MoveSpecification(D6, D2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1467,7 +1467,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white moves out of check
       final MoveSpecification move = new MoveSpecification(E1, F1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1487,7 +1487,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // let black move queen one more time
       final MoveSpecification move = new MoveSpecification(D2, C2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1507,7 +1507,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // let white move queen one more time
       final MoveSpecification move = new MoveSpecification(F7, G7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenAttackedSquares
@@ -1564,7 +1564,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // e4
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1582,7 +1582,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // d5
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1600,7 +1600,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white king walks to e2
       final MoveSpecification move = new MoveSpecification(E1, E2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1618,7 +1618,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black king walks to d7
       final MoveSpecification move = new MoveSpecification(E8, D7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1636,7 +1636,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white king walks to e3
       final MoveSpecification move = new MoveSpecification(E2, E3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1655,7 +1655,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black king walks to d6
       final MoveSpecification move = new MoveSpecification(D7, D6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1673,7 +1673,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white king walks to f4
       final MoveSpecification move = new MoveSpecification(E3, F4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1691,7 +1691,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black moves a pawn next to king
       final MoveSpecification move = new MoveSpecification(C7, C6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1709,7 +1709,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white moves a pawn next to king
       final MoveSpecification move = new MoveSpecification(G2, G4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1729,7 +1729,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
       // more square
       // available
       final MoveSpecification move = new MoveSpecification(C8, G4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1749,7 +1749,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
       // more square
       // available, white king has also one more square available e4
       final MoveSpecification move = new MoveSpecification(E4, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1767,7 +1767,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black checks white king with pawn
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1785,7 +1785,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white moves king away
       final MoveSpecification move = new MoveSpecification(F4, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1803,7 +1803,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black brings knight out
       final MoveSpecification move = new MoveSpecification(G8, F6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1821,53 +1821,53 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     // begin intermediary moves
     {
       final MoveSpecification move = new MoveSpecification(E4, D3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(F6, E8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(D3, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(A7, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(D1, E2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(G4, H3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(E2, H5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(H3, G4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(H5, H4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(H8, G8);
-      board.performMove(move);
+      board.move(move);
     }
     // end intermediary moves
 
     {
       final MoveSpecification move = new MoveSpecification(H4, H5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1885,7 +1885,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black checks king again
       final MoveSpecification move = new MoveSpecification(G4, F3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1903,7 +1903,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white king captures the checking piece
       final MoveSpecification move = new MoveSpecification(E4, F3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1921,11 +1921,11 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     // begin intermediary moves
     {
       final MoveSpecification move = new MoveSpecification(E8, F6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(A2, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     // end intermediary moves
@@ -1933,7 +1933,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black knight captures in the middle
       final MoveSpecification move = new MoveSpecification(F6, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1951,7 +1951,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white queen captures e5 and checks
       final MoveSpecification move = new MoveSpecification(H5, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -1969,7 +1969,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black king captures white queen
       final MoveSpecification move = new MoveSpecification(D6, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingAttackedSquares
@@ -2024,7 +2024,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // c4
       final MoveSpecification move = new MoveSpecification(C2, C4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2042,7 +2042,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // f5
       final MoveSpecification move = new MoveSpecification(F7, F5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2060,7 +2060,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // giving black pawn a white pawn to feed
       final MoveSpecification move = new MoveSpecification(G2, G4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2078,7 +2078,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // giving white pawn a black pawn to feed
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2098,7 +2098,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
       // supported in potential to level
       // now looking at the a-pawn
       final MoveSpecification move = new MoveSpecification(A2, A4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2116,7 +2116,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black captures the offered pawn
       final MoveSpecification move = new MoveSpecification(F5, G4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2135,7 +2135,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
       // white offers the en passant capture - but en passant not supported in potential to
       // level
       final MoveSpecification move = new MoveSpecification(H2, H4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2153,7 +2153,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black captures en passant
       final MoveSpecification move = new MoveSpecification(G4, H3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2171,7 +2171,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white further a-pawn advance
       final MoveSpecification move = new MoveSpecification(A4, A5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2189,7 +2189,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black allows en passant capture - but en passant not supported in potential to level
       final MoveSpecification move = new MoveSpecification(B7, B5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2207,7 +2207,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white captures en passant
       final MoveSpecification move = new MoveSpecification(A5, B6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2225,7 +2225,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black pushes h-pawn
       final MoveSpecification move = new MoveSpecification(H3, H2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2243,7 +2243,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white captures zig-zag for promotion - zig
       final MoveSpecification move = new MoveSpecification(B6, A7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2261,7 +2261,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black promotes to queen by capturing
       final MoveSpecification move = new MoveSpecification(H2, G1, PromotionPieceType.QUEEN);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2280,7 +2280,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white promotes to queen by capturing - zag
       final MoveSpecification move = new MoveSpecification(A7, B8, PromotionPieceType.QUEEN);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // we check the queen
@@ -2299,7 +2299,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black prepares offering rook for capturing by pawn
       final MoveSpecification move = new MoveSpecification(A8, A5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // we check the queen
@@ -2319,7 +2319,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
       // white does the same with the knight
       // we start focusing the capturing pawns now
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2337,7 +2337,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black offers the rook
       final MoveSpecification move = new MoveSpecification(A5, B5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2355,7 +2355,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // the pawn takes it
       final MoveSpecification move = new MoveSpecification(C4, B5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2373,7 +2373,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black attacks the pawn with a pawn
       final MoveSpecification move = new MoveSpecification(C7, C6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2391,7 +2391,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white offers the knight to a pawn
       final MoveSpecification move = new MoveSpecification(C3, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2409,7 +2409,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black captures the knight
       final MoveSpecification move = new MoveSpecification(D5, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2427,7 +2427,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white offers en passant
       final MoveSpecification move = new MoveSpecification(D2, D4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2445,7 +2445,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black ignores en passant
       final MoveSpecification move = new MoveSpecification(E8, D7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2464,7 +2464,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
       // white starts to ignore en passant
       // we look at whites f-pawn now
       final MoveSpecification move = new MoveSpecification(F2, F4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2483,7 +2483,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
       // black ignores en passant capture possibility - but en passant not supported
       // in potential to level
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2501,7 +2501,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // white f-pawn goes ahead
       final MoveSpecification move = new MoveSpecification(F4, F5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2519,7 +2519,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
     {
       // black offers en passant capture - but en passant not supported in potential to level
       final MoveSpecification move = new MoveSpecification(G7, G5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares
@@ -2538,7 +2538,7 @@ class TestAttackedSquaresByPlaying implements EnumConstants {
       // white ignores en passant capture - but en passant not supported in potential to
       // level
       final MoveSpecification move = new MoveSpecification(B2, B3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnAttackedSquares

--- a/src/test/java/com/dlb/chess/test/custom/TestPerformMoveMainlyStaticPositionState.java
+++ b/src/test/java/com/dlb/chess/test/custom/TestPerformMoveMainlyStaticPositionState.java
@@ -24,7 +24,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     StaticPosition workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move1W = new MoveSpecification(E2, E4);
-    apiBoard.performMove(move1W);
+    apiBoard.move(move1W);
     workingPosition = workingPosition.createChangedPosition(E2);
     final StaticPosition staticPosition1W = workingPosition.createChangedPosition(E4, WHITE_PAWN);
     assertEquals(staticPosition1W, apiBoard.getStaticPosition());
@@ -34,7 +34,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move1B = new MoveSpecification(C7, C5);
-    apiBoard.performMove(move1B);
+    apiBoard.move(move1B);
     workingPosition = workingPosition.createChangedPosition(C7);
     final StaticPosition staticPosition1B = workingPosition.createChangedPosition(C5, BLACK_PAWN);
     assertEquals(staticPosition1B, apiBoard.getStaticPosition());
@@ -44,7 +44,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move2W = new MoveSpecification(G1, F3);
-    apiBoard.performMove(move2W);
+    apiBoard.move(move2W);
     workingPosition = workingPosition.createChangedPosition(G1);
     final StaticPosition staticPosition2W = workingPosition.createChangedPosition(F3, WHITE_KNIGHT);
     assertEquals(staticPosition2W, apiBoard.getStaticPosition());
@@ -54,7 +54,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move2B = new MoveSpecification(B8, C6);
-    apiBoard.performMove(move2B);
+    apiBoard.move(move2B);
     workingPosition = workingPosition.createChangedPosition(B8);
     final StaticPosition staticPosition2B = workingPosition.createChangedPosition(C6, BLACK_KNIGHT);
     assertEquals(staticPosition2B, apiBoard.getStaticPosition());
@@ -64,7 +64,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move3W = new MoveSpecification(F1, C4);
-    apiBoard.performMove(move3W);
+    apiBoard.move(move3W);
     workingPosition = workingPosition.createChangedPosition(F1);
     final StaticPosition staticPosition3W = workingPosition.createChangedPosition(C4, WHITE_BISHOP);
     assertEquals(staticPosition3W, apiBoard.getStaticPosition());
@@ -74,7 +74,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move3B = new MoveSpecification(D7, D6);
-    apiBoard.performMove(move3B);
+    apiBoard.move(move3B);
     workingPosition = workingPosition.createChangedPosition(D7);
     final StaticPosition staticPosition3B = workingPosition.createChangedPosition(D6, BLACK_PAWN);
     assertEquals(staticPosition3B, apiBoard.getStaticPosition());
@@ -84,7 +84,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move4W = new MoveSpecification(B1, C3);
-    apiBoard.performMove(move4W);
+    apiBoard.move(move4W);
     workingPosition = workingPosition.createChangedPosition(B1);
     final StaticPosition staticPosition4W = workingPosition.createChangedPosition(C3, WHITE_KNIGHT);
     assertEquals(staticPosition4W, apiBoard.getStaticPosition());
@@ -94,7 +94,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move4B = new MoveSpecification(C8, G4);
-    apiBoard.performMove(move4B);
+    apiBoard.move(move4B);
     workingPosition = workingPosition.createChangedPosition(C8);
     final StaticPosition staticPosition4B = workingPosition.createChangedPosition(G4, BLACK_BISHOP);
     assertEquals(staticPosition4B, apiBoard.getStaticPosition());
@@ -104,7 +104,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move5W = new MoveSpecification(D2, D3);
-    apiBoard.performMove(move5W);
+    apiBoard.move(move5W);
     workingPosition = workingPosition.createChangedPosition(D2);
     final StaticPosition staticPosition5W = workingPosition.createChangedPosition(D3, WHITE_PAWN);
     assertEquals(staticPosition5W, apiBoard.getStaticPosition());
@@ -114,7 +114,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move5B = new MoveSpecification(G8, F6);
-    apiBoard.performMove(move5B);
+    apiBoard.move(move5B);
     workingPosition = workingPosition.createChangedPosition(G8);
     final StaticPosition staticPosition5B = workingPosition.createChangedPosition(F6, BLACK_KNIGHT);
     assertEquals(staticPosition5B, apiBoard.getStaticPosition());
@@ -124,7 +124,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move6W = new MoveSpecification(C1, F4);
-    apiBoard.performMove(move6W);
+    apiBoard.move(move6W);
     workingPosition = workingPosition.createChangedPosition(C1);
     final StaticPosition staticPosition6W = workingPosition.createChangedPosition(F4, WHITE_BISHOP);
     assertEquals(staticPosition6W, apiBoard.getStaticPosition());
@@ -134,7 +134,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move6B = new MoveSpecification(E7, E5);
-    apiBoard.performMove(move6B);
+    apiBoard.move(move6B);
     workingPosition = workingPosition.createChangedPosition(E7);
     final StaticPosition staticPosition6B = workingPosition.createChangedPosition(E5, BLACK_PAWN);
     assertEquals(staticPosition6B, apiBoard.getStaticPosition());
@@ -144,7 +144,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move7W = new MoveSpecification(D1, E2);
-    apiBoard.performMove(move7W);
+    apiBoard.move(move7W);
     workingPosition = workingPosition.createChangedPosition(D1);
     final StaticPosition staticPosition7W = workingPosition.createChangedPosition(E2, WHITE_QUEEN);
     assertEquals(staticPosition7W, apiBoard.getStaticPosition());
@@ -154,7 +154,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move7B = new MoveSpecification(F8, E7);
-    apiBoard.performMove(move7B);
+    apiBoard.move(move7B);
     workingPosition = workingPosition.createChangedPosition(F8);
     final StaticPosition staticPosition7B = workingPosition.createChangedPosition(E7, BLACK_BISHOP);
     assertEquals(staticPosition7B, apiBoard.getStaticPosition());
@@ -164,7 +164,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move8W = new MoveSpecification(A1, D1);
-    apiBoard.performMove(move8W);
+    apiBoard.move(move8W);
     workingPosition = workingPosition.createChangedPosition(A1);
     final StaticPosition staticPosition8W = workingPosition.createChangedPosition(D1, WHITE_ROOK);
     assertEquals(staticPosition8W, apiBoard.getStaticPosition());
@@ -174,7 +174,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move8B = new MoveSpecification(D8, D7);
-    apiBoard.performMove(move8B);
+    apiBoard.move(move8B);
     workingPosition = workingPosition.createChangedPosition(D8);
     final StaticPosition staticPosition8B = workingPosition.createChangedPosition(D7, BLACK_QUEEN);
     assertEquals(staticPosition8B, apiBoard.getStaticPosition());
@@ -184,7 +184,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move9W = new MoveSpecification(CastlingMove.KING_SIDE);
-    apiBoard.performMove(move9W);
+    apiBoard.move(move9W);
     workingPosition = workingPosition.createChangedPosition(E1);
     workingPosition = workingPosition.createChangedPosition(G1, WHITE_KING);
     workingPosition = workingPosition.createChangedPosition(H1);
@@ -196,7 +196,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move9B = new MoveSpecification(CastlingMove.QUEEN_SIDE);
-    apiBoard.performMove(move9B);
+    apiBoard.move(move9B);
     workingPosition = workingPosition.createChangedPosition(E8);
     workingPosition = workingPosition.createChangedPosition(C8, BLACK_KING);
     workingPosition = workingPosition.createChangedPosition(A8);
@@ -208,7 +208,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move10W = new MoveSpecification(F1, E1);
-    apiBoard.performMove(move10W);
+    apiBoard.move(move10W);
     workingPosition = workingPosition.createChangedPosition(F1);
     final StaticPosition staticPosition10W = workingPosition.createChangedPosition(E1, WHITE_ROOK);
     assertEquals(staticPosition10W, apiBoard.getStaticPosition());
@@ -218,7 +218,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move10B = new MoveSpecification(D8, E8);
-    apiBoard.performMove(move10B);
+    apiBoard.move(move10B);
     workingPosition = workingPosition.createChangedPosition(D8);
     final StaticPosition staticPosition10B = workingPosition.createChangedPosition(E8, BLACK_ROOK);
     assertEquals(staticPosition10B, apiBoard.getStaticPosition());
@@ -228,7 +228,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move11W = new MoveSpecification(G1, H1);
-    apiBoard.performMove(move11W);
+    apiBoard.move(move11W);
     workingPosition = workingPosition.createChangedPosition(G1);
     final StaticPosition staticPosition11W = workingPosition.createChangedPosition(H1, WHITE_KING);
     assertEquals(staticPosition11W, apiBoard.getStaticPosition());
@@ -238,7 +238,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move11B = new MoveSpecification(C8, B8);
-    apiBoard.performMove(move11B);
+    apiBoard.move(move11B);
     workingPosition = workingPosition.createChangedPosition(C8);
     final StaticPosition staticPosition11B = workingPosition.createChangedPosition(B8, BLACK_KING);
     assertEquals(staticPosition11B, apiBoard.getStaticPosition());
@@ -248,7 +248,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move12W = new MoveSpecification(H2, H4);
-    apiBoard.performMove(move12W);
+    apiBoard.move(move12W);
     workingPosition = workingPosition.createChangedPosition(H2);
     final StaticPosition staticPosition12W = workingPosition.createChangedPosition(H4, WHITE_PAWN);
     assertEquals(staticPosition12W, apiBoard.getStaticPosition());
@@ -258,7 +258,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move12B = new MoveSpecification(A7, A5);
-    apiBoard.performMove(move12B);
+    apiBoard.move(move12B);
     workingPosition = workingPosition.createChangedPosition(A7);
     final StaticPosition staticPosition12B = workingPosition.createChangedPosition(A5, BLACK_PAWN);
     assertEquals(staticPosition12B, apiBoard.getStaticPosition());
@@ -268,7 +268,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move13W = new MoveSpecification(H4, H5);
-    apiBoard.performMove(move13W);
+    apiBoard.move(move13W);
     workingPosition = workingPosition.createChangedPosition(H4);
     final StaticPosition staticPosition13W = workingPosition.createChangedPosition(H5, WHITE_PAWN);
     assertEquals(staticPosition13W, apiBoard.getStaticPosition());
@@ -278,7 +278,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move13B = new MoveSpecification(G7, G5);
-    apiBoard.performMove(move13B);
+    apiBoard.move(move13B);
     workingPosition = workingPosition.createChangedPosition(G7);
     final StaticPosition staticPosition13B = workingPosition.createChangedPosition(G5, BLACK_PAWN);
     assertEquals(staticPosition13B, apiBoard.getStaticPosition());
@@ -288,7 +288,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move14W = new MoveSpecification(H5, G6);
-    apiBoard.performMove(move14W);
+    apiBoard.move(move14W);
     workingPosition = workingPosition.createChangedPosition(H5);
     workingPosition = workingPosition.createChangedPosition(G6, WHITE_PAWN);
     final StaticPosition staticPosition14W = workingPosition.createChangedPosition(G5);
@@ -299,7 +299,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move14B = new MoveSpecification(A5, A4);
-    apiBoard.performMove(move14B);
+    apiBoard.move(move14B);
     workingPosition = workingPosition.createChangedPosition(A5);
     final StaticPosition staticPosition14B = workingPosition.createChangedPosition(A4, BLACK_PAWN);
     assertEquals(staticPosition14B, apiBoard.getStaticPosition());
@@ -309,7 +309,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move15W = new MoveSpecification(B2, B4);
-    apiBoard.performMove(move15W);
+    apiBoard.move(move15W);
     workingPosition = workingPosition.createChangedPosition(B2);
     final StaticPosition staticPosition15W = workingPosition.createChangedPosition(B4, WHITE_PAWN);
     assertEquals(staticPosition15W, apiBoard.getStaticPosition());
@@ -319,7 +319,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move15B = new MoveSpecification(A4, B3);
-    apiBoard.performMove(move15B);
+    apiBoard.move(move15B);
     workingPosition = workingPosition.createChangedPosition(A4);
     workingPosition = workingPosition.createChangedPosition(B3, BLACK_PAWN);
     final StaticPosition staticPosition15B = workingPosition.createChangedPosition(B4);
@@ -330,7 +330,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move16W = new MoveSpecification(G6, H7);
-    apiBoard.performMove(move16W);
+    apiBoard.move(move16W);
     workingPosition = workingPosition.createChangedPosition(G6);
     final StaticPosition staticPosition16W = workingPosition.createChangedPosition(H7, WHITE_PAWN);
     assertEquals(staticPosition16W, apiBoard.getStaticPosition());
@@ -340,7 +340,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move16B = new MoveSpecification(B3, A2);
-    apiBoard.performMove(move16B);
+    apiBoard.move(move16B);
     workingPosition = workingPosition.createChangedPosition(B3);
     final StaticPosition staticPosition16B = workingPosition.createChangedPosition(A2, BLACK_PAWN);
     assertEquals(staticPosition16B, apiBoard.getStaticPosition());
@@ -350,7 +350,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move17W = new MoveSpecification(F4, E5);
-    apiBoard.performMove(move17W);
+    apiBoard.move(move17W);
     workingPosition = workingPosition.createChangedPosition(F4);
     final StaticPosition staticPosition17W = workingPosition.createChangedPosition(E5, WHITE_BISHOP);
     assertEquals(staticPosition17W, apiBoard.getStaticPosition());
@@ -360,7 +360,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move17B = new MoveSpecification(A2, A1, PromotionPieceType.QUEEN);
-    apiBoard.performMove(move17B);
+    apiBoard.move(move17B);
     workingPosition = workingPosition.createChangedPosition(A2);
     final StaticPosition staticPosition17B = workingPosition.createChangedPosition(A1, BLACK_QUEEN);
     assertEquals(staticPosition17B, apiBoard.getStaticPosition());
@@ -370,7 +370,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move18W = new MoveSpecification(F3, G5);
-    apiBoard.performMove(move18W);
+    apiBoard.move(move18W);
     workingPosition = workingPosition.createChangedPosition(F3);
     final StaticPosition staticPosition18W = workingPosition.createChangedPosition(G5, WHITE_KNIGHT);
     assertEquals(staticPosition18W, apiBoard.getStaticPosition());
@@ -380,7 +380,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move18B = new MoveSpecification(H8, G8);
-    apiBoard.performMove(move18B);
+    apiBoard.move(move18B);
     workingPosition = workingPosition.createChangedPosition(H8);
     final StaticPosition staticPosition18B = workingPosition.createChangedPosition(G8, BLACK_ROOK);
     assertEquals(staticPosition18B, apiBoard.getStaticPosition());
@@ -390,7 +390,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move19W = new MoveSpecification(H7, G8, PromotionPieceType.KNIGHT);
-    apiBoard.performMove(move19W);
+    apiBoard.move(move19W);
     workingPosition = workingPosition.createChangedPosition(H7);
     final StaticPosition staticPosition19W = workingPosition.createChangedPosition(G8, WHITE_KNIGHT);
     assertEquals(staticPosition19W, apiBoard.getStaticPosition());
@@ -400,7 +400,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move19B = new MoveSpecification(C6, A5);
-    apiBoard.performMove(move19B);
+    apiBoard.move(move19B);
     workingPosition = workingPosition.createChangedPosition(C6);
     final StaticPosition staticPosition19B = workingPosition.createChangedPosition(A5, BLACK_KNIGHT);
     assertEquals(staticPosition19B, apiBoard.getStaticPosition());
@@ -410,7 +410,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move20W = new MoveSpecification(G5, F7);
-    apiBoard.performMove(move20W);
+    apiBoard.move(move20W);
     workingPosition = workingPosition.createChangedPosition(G5);
     final StaticPosition staticPosition20W = workingPosition.createChangedPosition(F7, WHITE_KNIGHT);
     assertEquals(staticPosition20W, apiBoard.getStaticPosition());
@@ -420,7 +420,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move20B = new MoveSpecification(A5, C4);
-    apiBoard.performMove(move20B);
+    apiBoard.move(move20B);
     workingPosition = workingPosition.createChangedPosition(A5);
     final StaticPosition staticPosition20B = workingPosition.createChangedPosition(C4, BLACK_KNIGHT);
     assertEquals(staticPosition20B, apiBoard.getStaticPosition());
@@ -430,7 +430,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move21W = new MoveSpecification(G8, E7);
-    apiBoard.performMove(move21W);
+    apiBoard.move(move21W);
     workingPosition = workingPosition.createChangedPosition(G8);
     final StaticPosition staticPosition21W = workingPosition.createChangedPosition(E7, WHITE_KNIGHT);
     assertEquals(staticPosition21W, apiBoard.getStaticPosition());
@@ -440,7 +440,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move21B = new MoveSpecification(E8, E7);
-    apiBoard.performMove(move21B);
+    apiBoard.move(move21B);
     workingPosition = workingPosition.createChangedPosition(E8);
     final StaticPosition staticPosition21B = workingPosition.createChangedPosition(E7, BLACK_ROOK);
     assertEquals(staticPosition21B, apiBoard.getStaticPosition());
@@ -450,7 +450,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move22W = new MoveSpecification(F2, F3);
-    apiBoard.performMove(move22W);
+    apiBoard.move(move22W);
     workingPosition = workingPosition.createChangedPosition(F2);
     final StaticPosition staticPosition22W = workingPosition.createChangedPosition(F3, WHITE_PAWN);
     assertEquals(staticPosition22W, apiBoard.getStaticPosition());
@@ -460,7 +460,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move22B = new MoveSpecification(A1, D1);
-    apiBoard.performMove(move22B);
+    apiBoard.move(move22B);
     workingPosition = workingPosition.createChangedPosition(A1);
     final StaticPosition staticPosition22B = workingPosition.createChangedPosition(D1, BLACK_QUEEN);
     assertEquals(staticPosition22B, apiBoard.getStaticPosition());
@@ -470,7 +470,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move23W = new MoveSpecification(E1, D1);
-    apiBoard.performMove(move23W);
+    apiBoard.move(move23W);
     workingPosition = workingPosition.createChangedPosition(E1);
     final StaticPosition staticPosition23W = workingPosition.createChangedPosition(D1, WHITE_ROOK);
     assertEquals(staticPosition23W, apiBoard.getStaticPosition());
@@ -480,7 +480,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move23B = new MoveSpecification(G4, F3);
-    apiBoard.performMove(move23B);
+    apiBoard.move(move23B);
     workingPosition = workingPosition.createChangedPosition(G4);
     final StaticPosition staticPosition23B = workingPosition.createChangedPosition(F3, BLACK_BISHOP);
     assertEquals(staticPosition23B, apiBoard.getStaticPosition());
@@ -490,7 +490,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move24W = new MoveSpecification(G2, F3);
-    apiBoard.performMove(move24W);
+    apiBoard.move(move24W);
     workingPosition = workingPosition.createChangedPosition(G2);
     final StaticPosition staticPosition24W = workingPosition.createChangedPosition(F3, WHITE_PAWN);
     assertEquals(staticPosition24W, apiBoard.getStaticPosition());
@@ -500,7 +500,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move24B = new MoveSpecification(C4, E5);
-    apiBoard.performMove(move24B);
+    apiBoard.move(move24B);
     workingPosition = workingPosition.createChangedPosition(C4);
     final StaticPosition staticPosition24B = workingPosition.createChangedPosition(E5, BLACK_KNIGHT);
     assertEquals(staticPosition24B, apiBoard.getStaticPosition());
@@ -510,7 +510,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move25W = new MoveSpecification(F7, E5);
-    apiBoard.performMove(move25W);
+    apiBoard.move(move25W);
     workingPosition = workingPosition.createChangedPosition(F7);
     final StaticPosition staticPosition25W = workingPosition.createChangedPosition(E5, WHITE_KNIGHT);
     assertEquals(staticPosition25W, apiBoard.getStaticPosition());
@@ -520,7 +520,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move25B = new MoveSpecification(F6, E4);
-    apiBoard.performMove(move25B);
+    apiBoard.move(move25B);
     workingPosition = workingPosition.createChangedPosition(F6);
     final StaticPosition staticPosition25B = workingPosition.createChangedPosition(E4, BLACK_KNIGHT);
     assertEquals(staticPosition25B, apiBoard.getStaticPosition());
@@ -530,7 +530,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move26W = new MoveSpecification(D3, E4);
-    apiBoard.performMove(move26W);
+    apiBoard.move(move26W);
     workingPosition = workingPosition.createChangedPosition(D3);
     final StaticPosition staticPosition26W = workingPosition.createChangedPosition(E4, WHITE_PAWN);
     assertEquals(staticPosition26W, apiBoard.getStaticPosition());
@@ -540,7 +540,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move26B = new MoveSpecification(E7, E5);
-    apiBoard.performMove(move26B);
+    apiBoard.move(move26B);
     workingPosition = workingPosition.createChangedPosition(E7);
     final StaticPosition staticPosition26B = workingPosition.createChangedPosition(E5, BLACK_ROOK);
     assertEquals(staticPosition26B, apiBoard.getStaticPosition());
@@ -550,7 +550,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move27W = new MoveSpecification(D1, D6);
-    apiBoard.performMove(move27W);
+    apiBoard.move(move27W);
     workingPosition = workingPosition.createChangedPosition(D1);
     final StaticPosition staticPosition27W = workingPosition.createChangedPosition(D6, WHITE_ROOK);
     assertEquals(staticPosition27W, apiBoard.getStaticPosition());
@@ -560,7 +560,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move27B = new MoveSpecification(D7, D6);
-    apiBoard.performMove(move27B);
+    apiBoard.move(move27B);
     workingPosition = workingPosition.createChangedPosition(D7);
     final StaticPosition staticPosition27B = workingPosition.createChangedPosition(D6, BLACK_QUEEN);
     assertEquals(staticPosition27B, apiBoard.getStaticPosition());
@@ -570,7 +570,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move28W = new MoveSpecification(C3, D5);
-    apiBoard.performMove(move28W);
+    apiBoard.move(move28W);
     workingPosition = workingPosition.createChangedPosition(C3);
     final StaticPosition staticPosition28W = workingPosition.createChangedPosition(D5, WHITE_KNIGHT);
     assertEquals(staticPosition28W, apiBoard.getStaticPosition());
@@ -580,7 +580,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move28B = new MoveSpecification(E5, E4);
-    apiBoard.performMove(move28B);
+    apiBoard.move(move28B);
     workingPosition = workingPosition.createChangedPosition(E5);
     final StaticPosition staticPosition28B = workingPosition.createChangedPosition(E4, BLACK_ROOK);
     assertEquals(staticPosition28B, apiBoard.getStaticPosition());
@@ -590,7 +590,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move29W = new MoveSpecification(E2, E4);
-    apiBoard.performMove(move29W);
+    apiBoard.move(move29W);
     workingPosition = workingPosition.createChangedPosition(E2);
     final StaticPosition staticPosition29W = workingPosition.createChangedPosition(E4, WHITE_QUEEN);
     assertEquals(staticPosition29W, apiBoard.getStaticPosition());
@@ -600,7 +600,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move29B = new MoveSpecification(D6, D5);
-    apiBoard.performMove(move29B);
+    apiBoard.move(move29B);
     workingPosition = workingPosition.createChangedPosition(D6);
     final StaticPosition staticPosition29B = workingPosition.createChangedPosition(D5, BLACK_QUEEN);
     assertEquals(staticPosition29B, apiBoard.getStaticPosition());
@@ -610,7 +610,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move30W = new MoveSpecification(E4, D5);
-    apiBoard.performMove(move30W);
+    apiBoard.move(move30W);
     workingPosition = workingPosition.createChangedPosition(E4);
     final StaticPosition staticPosition30W = workingPosition.createChangedPosition(D5, WHITE_QUEEN);
     assertEquals(staticPosition30W, apiBoard.getStaticPosition());
@@ -620,7 +620,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move30B = new MoveSpecification(B7, B5);
-    apiBoard.performMove(move30B);
+    apiBoard.move(move30B);
     workingPosition = workingPosition.createChangedPosition(B7);
     final StaticPosition staticPosition30B = workingPosition.createChangedPosition(B5, BLACK_PAWN);
     assertEquals(staticPosition30B, apiBoard.getStaticPosition());
@@ -630,7 +630,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move31W = new MoveSpecification(C2, C4);
-    apiBoard.performMove(move31W);
+    apiBoard.move(move31W);
     workingPosition = workingPosition.createChangedPosition(C2);
     final StaticPosition staticPosition31W = workingPosition.createChangedPosition(C4, WHITE_PAWN);
     assertEquals(staticPosition31W, apiBoard.getStaticPosition());
@@ -640,7 +640,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move31B = new MoveSpecification(B5, C4);
-    apiBoard.performMove(move31B);
+    apiBoard.move(move31B);
     workingPosition = workingPosition.createChangedPosition(B5);
     final StaticPosition staticPosition31B = workingPosition.createChangedPosition(C4, BLACK_PAWN);
     assertEquals(staticPosition31B, apiBoard.getStaticPosition());
@@ -650,7 +650,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move32W = new MoveSpecification(F3, F4);
-    apiBoard.performMove(move32W);
+    apiBoard.move(move32W);
     workingPosition = workingPosition.createChangedPosition(F3);
     final StaticPosition staticPosition32W = workingPosition.createChangedPosition(F4, WHITE_PAWN);
     assertEquals(staticPosition32W, apiBoard.getStaticPosition());
@@ -660,7 +660,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move32B = new MoveSpecification(B8, C7);
-    apiBoard.performMove(move32B);
+    apiBoard.move(move32B);
     workingPosition = workingPosition.createChangedPosition(B8);
     final StaticPosition staticPosition32B = workingPosition.createChangedPosition(C7, BLACK_KING);
     assertEquals(staticPosition32B, apiBoard.getStaticPosition());
@@ -670,7 +670,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move33W = new MoveSpecification(D5, C4);
-    apiBoard.performMove(move33W);
+    apiBoard.move(move33W);
     workingPosition = workingPosition.createChangedPosition(D5);
     final StaticPosition staticPosition33W = workingPosition.createChangedPosition(C4, WHITE_QUEEN);
     assertEquals(staticPosition33W, apiBoard.getStaticPosition());
@@ -680,7 +680,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move33B = new MoveSpecification(C7, D6);
-    apiBoard.performMove(move33B);
+    apiBoard.move(move33B);
     workingPosition = workingPosition.createChangedPosition(C7);
     final StaticPosition staticPosition33B = workingPosition.createChangedPosition(D6, BLACK_KING);
     assertEquals(staticPosition33B, apiBoard.getStaticPosition());
@@ -690,7 +690,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move34W = new MoveSpecification(C4, C3);
-    apiBoard.performMove(move34W);
+    apiBoard.move(move34W);
     workingPosition = workingPosition.createChangedPosition(C4);
     final StaticPosition staticPosition34W = workingPosition.createChangedPosition(C3, WHITE_QUEEN);
     assertEquals(staticPosition34W, apiBoard.getStaticPosition());
@@ -700,7 +700,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move34B = new MoveSpecification(D6, E6);
-    apiBoard.performMove(move34B);
+    apiBoard.move(move34B);
     workingPosition = workingPosition.createChangedPosition(D6);
     final StaticPosition staticPosition34B = workingPosition.createChangedPosition(E6, BLACK_KING);
     assertEquals(staticPosition34B, apiBoard.getStaticPosition());
@@ -710,7 +710,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move35W = new MoveSpecification(C3, C2);
-    apiBoard.performMove(move35W);
+    apiBoard.move(move35W);
     workingPosition = workingPosition.createChangedPosition(C3);
     final StaticPosition staticPosition35W = workingPosition.createChangedPosition(C2, WHITE_QUEEN);
     assertEquals(staticPosition35W, apiBoard.getStaticPosition());
@@ -720,7 +720,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move35B = new MoveSpecification(E6, F6);
-    apiBoard.performMove(move35B);
+    apiBoard.move(move35B);
     workingPosition = workingPosition.createChangedPosition(E6);
     final StaticPosition staticPosition35B = workingPosition.createChangedPosition(F6, BLACK_KING);
     assertEquals(staticPosition35B, apiBoard.getStaticPosition());
@@ -730,7 +730,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move36W = new MoveSpecification(F4, F5);
-    apiBoard.performMove(move36W);
+    apiBoard.move(move36W);
     workingPosition = workingPosition.createChangedPosition(F4);
     final StaticPosition staticPosition36W = workingPosition.createChangedPosition(F5, WHITE_PAWN);
     assertEquals(staticPosition36W, apiBoard.getStaticPosition());
@@ -740,7 +740,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move36B = new MoveSpecification(F6, G5);
-    apiBoard.performMove(move36B);
+    apiBoard.move(move36B);
     workingPosition = workingPosition.createChangedPosition(F6);
     final StaticPosition staticPosition36B = workingPosition.createChangedPosition(G5, BLACK_KING);
     assertEquals(staticPosition36B, apiBoard.getStaticPosition());
@@ -750,7 +750,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move37W = new MoveSpecification(C2, C3);
-    apiBoard.performMove(move37W);
+    apiBoard.move(move37W);
     workingPosition = workingPosition.createChangedPosition(C2);
     final StaticPosition staticPosition37W = workingPosition.createChangedPosition(C3, WHITE_QUEEN);
     assertEquals(staticPosition37W, apiBoard.getStaticPosition());
@@ -760,7 +760,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move37B = new MoveSpecification(G5, F5);
-    apiBoard.performMove(move37B);
+    apiBoard.move(move37B);
     workingPosition = workingPosition.createChangedPosition(G5);
     final StaticPosition staticPosition37B = workingPosition.createChangedPosition(F5, BLACK_KING);
     assertEquals(staticPosition37B, apiBoard.getStaticPosition());
@@ -770,7 +770,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move38W = new MoveSpecification(C3, C5);
-    apiBoard.performMove(move38W);
+    apiBoard.move(move38W);
     workingPosition = workingPosition.createChangedPosition(C3);
     final StaticPosition staticPosition38W = workingPosition.createChangedPosition(C5, WHITE_QUEEN);
     assertEquals(staticPosition38W, apiBoard.getStaticPosition());
@@ -780,7 +780,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move38B = new MoveSpecification(F5, F4);
-    apiBoard.performMove(move38B);
+    apiBoard.move(move38B);
     workingPosition = workingPosition.createChangedPosition(F5);
     final StaticPosition staticPosition38B = workingPosition.createChangedPosition(F4, BLACK_KING);
     assertEquals(staticPosition38B, apiBoard.getStaticPosition());
@@ -790,7 +790,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move39W = new MoveSpecification(C5, F5);
-    apiBoard.performMove(move39W);
+    apiBoard.move(move39W);
     workingPosition = workingPosition.createChangedPosition(C5);
     final StaticPosition staticPosition39W = workingPosition.createChangedPosition(F5, WHITE_QUEEN);
     assertEquals(staticPosition39W, apiBoard.getStaticPosition());
@@ -800,7 +800,7 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
 
     workingPosition = apiBoard.getStaticPosition();
     final MoveSpecification move39B = new MoveSpecification(F4, F5);
-    apiBoard.performMove(move39B);
+    apiBoard.move(move39B);
     workingPosition = workingPosition.createChangedPosition(F4);
     final StaticPosition staticPosition39B = workingPosition.createChangedPosition(F5, BLACK_KING);
     assertEquals(staticPosition39B, apiBoard.getStaticPosition());
@@ -809,315 +809,315 @@ class TestPerformMoveMainlyStaticPositionState implements EnumConstants {
     assertEquals("Kf4xf5", apiBoard.getLan());
 
     // undo the moves
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition39W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition38B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition38W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition37B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition37W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition36B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition36W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition35B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition35W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition34B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition34W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition33B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition33W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition32B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition32W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition31B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition31W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition30B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition30W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition29B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition29W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition28B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition28W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition27B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition27W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition26B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition26W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition25B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition25W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition24B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition24W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition23B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition23W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition22B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition22W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition21B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition21W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition20B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition20W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition19B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition19W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition18B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition18W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition17B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition17W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition16B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition16W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition15B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition15W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition14B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition14W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition13B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition13W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition12B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition12W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition11B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition11W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition10B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition10W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition9B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition9W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition8B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition8W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition7B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition7W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition6B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition6W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition5B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition5W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition4B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition4W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition3B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition3W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition2B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition2W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition1B, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition1W, apiBoard.getStaticPosition());
     assertEquals(BLACK, apiBoard.getHavingMove());
 
-    apiBoard.unperformMove();
+    apiBoard.unmove();
     assertEquals(staticPosition0, apiBoard.getStaticPosition());
     assertEquals(WHITE, apiBoard.getHavingMove());
   }

--- a/src/test/java/com/dlb/chess/test/custom/TestPerformMoveSeveralStates.java
+++ b/src/test/java/com/dlb/chess/test/custom/TestPerformMoveSeveralStates.java
@@ -46,7 +46,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightWhite()));
       assertEquals(0, board.getHalfMoveClock());
 
-      board.performMove(halfMoveWhite);
+      board.move(halfMoveWhite);
 
       // test after move
       assertEquals("e4", board.getSan());
@@ -88,7 +88,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightBlack()));
 
-      board.performMove(halfMoveBlack);
+      board.move(halfMoveBlack);
 
       // test after move
       assertEquals("d5", board.getSan());
@@ -128,7 +128,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightWhite()));
 
-      board.performMove(halfMoveWhite);
+      board.move(halfMoveWhite);
 
       // test after move
       assertEquals("exd5", board.getSan());
@@ -168,7 +168,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightBlack()));
 
-      board.performMove(halfMoveBlack);
+      board.move(halfMoveBlack);
 
       // test after move
       assertEquals("Qxd5", board.getSan());
@@ -208,7 +208,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightWhite()));
 
-      board.performMove(halfMoveWhite);
+      board.move(halfMoveWhite);
 
       // test after move
       assertEquals("g4", board.getSan());
@@ -248,7 +248,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightBlack()));
 
-      board.performMove(halfMoveBlack);
+      board.move(halfMoveBlack);
 
       // test after move
       assertEquals("Bd7", board.getSan());
@@ -288,7 +288,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightWhite()));
 
-      board.performMove(halfMoveWhite);
+      board.move(halfMoveWhite);
 
       // test after move
       assertEquals("g5", board.getSan());
@@ -328,7 +328,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightBlack()));
 
-      board.performMove(halfMoveBlack);
+      board.move(halfMoveBlack);
 
       // test after move
       assertEquals("f5", board.getSan());
@@ -368,7 +368,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightWhite()));
 
-      board.performMove(halfMoveWhite);
+      board.move(halfMoveWhite);
 
       // test after move
       assertEquals("gxf6", board.getSan());
@@ -408,7 +408,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightBlack()));
 
-      board.performMove(halfMoveBlack);
+      board.move(halfMoveBlack);
 
       // test after move
       assertEquals("Nc6", board.getSan());
@@ -448,7 +448,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightWhite()));
 
-      board.performMove(halfMoveWhite);
+      board.move(halfMoveWhite);
 
       // test after move
       assertEquals("Nf3", board.getSan());
@@ -488,7 +488,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightBlack()));
 
-      board.performMove(halfMoveBlack);
+      board.move(halfMoveBlack);
 
       // test after move
       assertEquals("a5", board.getSan());
@@ -528,7 +528,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightWhite()));
 
-      board.performMove(halfMoveWhite);
+      board.move(halfMoveWhite);
 
       // test after move
       assertEquals("Bc4", board.getSan());
@@ -568,7 +568,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY, CastlingUtility
           .calculateKingSideCastlingCheck(board.getStaticPosition(), havingMove, board.getCastlingRightBlack()));
 
-      board.performMove(halfMoveBlack);
+      board.move(halfMoveBlack);
 
       // test after move
       assertEquals("a4", board.getSan());
@@ -608,7 +608,7 @@ class TestPerformMoveSeveralStates implements EnumConstants {
       assertEquals(CastlingCheck.SUCCESS, CastlingUtility.calculateKingSideCastlingCheck(board.getStaticPosition(),
           havingMove, board.getCastlingRightWhite()));
 
-      board.performMove(halfMoveWhite);
+      board.move(halfMoveWhite);
 
       // test after move
       assertEquals("Nc3", board.getSan());

--- a/src/test/java/com/dlb/chess/test/custom/TestPotentialToSquares.java
+++ b/src/test/java/com/dlb/chess/test/custom/TestPotentialToSquares.java
@@ -78,7 +78,7 @@ class TestPotentialToSquares implements EnumConstants {
     // black
     {
       final MoveSpecification move = new MoveSpecification(A2, A4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -96,7 +96,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H7, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -114,7 +114,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(A1, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -132,7 +132,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H5, H4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -150,7 +150,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(A3, D3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -168,7 +168,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H8, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -186,7 +186,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D3, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -204,7 +204,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H5, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -222,7 +222,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E2, E3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -240,7 +240,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -258,7 +258,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D1, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -276,7 +276,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(C6, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -294,7 +294,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(F1, B5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -312,7 +312,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D4, F5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -331,7 +331,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // waiting move
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -350,7 +350,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black checks
       final MoveSpecification move = new MoveSpecification(E5, E3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -369,7 +369,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white blocks check with knight
       final MoveSpecification move = new MoveSpecification(G1, E2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -425,7 +425,7 @@ class TestPotentialToSquares implements EnumConstants {
     // black
     {
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -443,7 +443,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(G8, H6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -461,7 +461,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(C3, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -479,7 +479,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H6, G4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -497,7 +497,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(C2, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -515,7 +515,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H7, H6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -533,7 +533,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H2, H4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -551,7 +551,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E7, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -569,7 +569,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(H1, H2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -587,7 +587,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D8, E7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -606,7 +606,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white checks
       final MoveSpecification move = new MoveSpecification(D5, F6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -625,7 +625,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black moves out of check
       final MoveSpecification move = new MoveSpecification(E8, D8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -643,7 +643,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -661,7 +661,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E7, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -679,7 +679,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(F1, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -697,7 +697,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(D6, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -715,7 +715,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E1, F1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -734,7 +734,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black checks
       final MoveSpecification move = new MoveSpecification(G4, H2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -753,7 +753,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white moves out of check
       final MoveSpecification move = new MoveSpecification(F1, E2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -821,7 +821,7 @@ class TestPotentialToSquares implements EnumConstants {
     // now we are making moves
     {
       final MoveSpecification move = new MoveSpecification(B2, B3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -839,7 +839,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(E7, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -857,7 +857,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(C1, B2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -875,7 +875,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(F8, C5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -893,7 +893,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(B2, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -911,7 +911,7 @@ class TestPotentialToSquares implements EnumConstants {
 
     {
       final MoveSpecification move = new MoveSpecification(G7, G6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -930,7 +930,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // capture the rook with white's bishop so black bishop can later check
       final MoveSpecification move = new MoveSpecification(D4, H8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -949,7 +949,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black retreats bishop as waiting move so can free a square for white king
       final MoveSpecification move = new MoveSpecification(C5, B6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -969,7 +969,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white prepares development of light square bishop so can check later
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -989,7 +989,7 @@ class TestPotentialToSquares implements EnumConstants {
       // we need another waiting move for black for prepare square so white king can
       // move out of check, we give retreat square
       final MoveSpecification move = new MoveSpecification(A7, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1008,7 +1008,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // free the square for white king
       final MoveSpecification move = new MoveSpecification(D1, C1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1027,7 +1027,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black checks
       final MoveSpecification move = new MoveSpecification(B6, F2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1046,7 +1046,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white moves out of check
       final MoveSpecification move = new MoveSpecification(E1, D1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopPotentialToSquares
@@ -1064,7 +1064,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black takes the knight
       final MoveSpecification move = new MoveSpecification(F2, G1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopPotentialToSquares
@@ -1082,7 +1082,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white takes out the bishop for later check
       final MoveSpecification move = new MoveSpecification(F1, C4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopPotentialToSquares
@@ -1100,7 +1100,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black moves pawn so white bishop can check
       final MoveSpecification move = new MoveSpecification(E6, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopPotentialToSquares
@@ -1118,7 +1118,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white checks
       final MoveSpecification move = new MoveSpecification(C4, F7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopPotentialToSquares
@@ -1136,7 +1136,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black moves out of check
       final MoveSpecification move = new MoveSpecification(E8, F8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = BishopPotentialToSquares
@@ -1190,7 +1190,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // e4
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1208,7 +1208,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // d5
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1226,7 +1226,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white queen enters the game
       final MoveSpecification move = new MoveSpecification(D1, H5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1245,7 +1245,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // take away one square from white queen by black piece
       final MoveSpecification move = new MoveSpecification(G8, H6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1264,7 +1264,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // take away one more square from white queen by white piece
       final MoveSpecification move = new MoveSpecification(G1, H3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1283,7 +1283,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // a black dummy move, not changing anything
       final MoveSpecification move = new MoveSpecification(H8, G8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1302,7 +1302,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white queen goes for d5
       final MoveSpecification move = new MoveSpecification(H5, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1321,7 +1321,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black queen comes out
       final MoveSpecification move = new MoveSpecification(D8, D6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1341,7 +1341,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white checks
       final MoveSpecification move = new MoveSpecification(D5, F7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1361,7 +1361,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black moves out of check
       final MoveSpecification move = new MoveSpecification(E8, D8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1381,7 +1381,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white moves out bishop to later take away a few squares from black queen
       final MoveSpecification move = new MoveSpecification(F1, B5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1401,7 +1401,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black makes a dummy move
       final MoveSpecification move = new MoveSpecification(G8, H8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1421,7 +1421,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white takes away two squares from black queen
       final MoveSpecification move = new MoveSpecification(B5, C6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1441,7 +1441,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black checks
       final MoveSpecification move = new MoveSpecification(D6, D2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1461,7 +1461,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white moves out of check
       final MoveSpecification move = new MoveSpecification(E1, F1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1481,7 +1481,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // let black move queen one more time
       final MoveSpecification move = new MoveSpecification(D2, C2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1501,7 +1501,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // let white move queen one more time
       final MoveSpecification move = new MoveSpecification(F7, G7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = QueenPotentialToSquares
@@ -1556,7 +1556,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // e4
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1574,7 +1574,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // d5
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1592,7 +1592,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white king walks to e2
       final MoveSpecification move = new MoveSpecification(E1, E2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1610,7 +1610,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black king walks to d7
       final MoveSpecification move = new MoveSpecification(E8, D7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1628,7 +1628,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white king walks to e3
       final MoveSpecification move = new MoveSpecification(E2, E3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1646,7 +1646,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black king walks to d6
       final MoveSpecification move = new MoveSpecification(D7, D6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1664,7 +1664,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white king walks to f4
       final MoveSpecification move = new MoveSpecification(E3, F4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1682,7 +1682,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black moves a pawn next to king
       final MoveSpecification move = new MoveSpecification(C7, C6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1700,7 +1700,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white moves a pawn next to king
       final MoveSpecification move = new MoveSpecification(G2, G4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1720,7 +1720,7 @@ class TestPotentialToSquares implements EnumConstants {
       // more square
       // available
       final MoveSpecification move = new MoveSpecification(C8, G4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1740,7 +1740,7 @@ class TestPotentialToSquares implements EnumConstants {
       // more square
       // available, white king has also one more square available e4
       final MoveSpecification move = new MoveSpecification(E4, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1758,7 +1758,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black checks white king with pawn
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1776,7 +1776,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white moves king away
       final MoveSpecification move = new MoveSpecification(F4, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1794,7 +1794,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black brings knight out
       final MoveSpecification move = new MoveSpecification(G8, F6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1812,53 +1812,53 @@ class TestPotentialToSquares implements EnumConstants {
     // begin intermediary moves
     {
       final MoveSpecification move = new MoveSpecification(E4, D3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(F6, E8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(D3, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(A7, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(D1, E2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(G4, H3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(E2, H5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(H3, G4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(H5, H4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(H8, G8);
-      board.performMove(move);
+      board.move(move);
     }
     // end intermediary moves
 
     {
       final MoveSpecification move = new MoveSpecification(H4, H5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1876,7 +1876,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black checks king again
       final MoveSpecification move = new MoveSpecification(G4, F3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1894,7 +1894,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white king captures the checking piece
       final MoveSpecification move = new MoveSpecification(E4, F3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1912,11 +1912,11 @@ class TestPotentialToSquares implements EnumConstants {
     // begin intermediary moves
     {
       final MoveSpecification move = new MoveSpecification(E8, F6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(A2, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     // end intermediary moves
@@ -1924,7 +1924,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black knight captures in the middle
       final MoveSpecification move = new MoveSpecification(F6, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1942,7 +1942,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white queen captures e5 and checks
       final MoveSpecification move = new MoveSpecification(H5, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -1960,7 +1960,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black king captures white queen
       final MoveSpecification move = new MoveSpecification(D6, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = KingNonCastlingPotentialToSquares
@@ -2013,7 +2013,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // c4
       final MoveSpecification move = new MoveSpecification(C2, C4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2031,7 +2031,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // f5
       final MoveSpecification move = new MoveSpecification(F7, F5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2049,7 +2049,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // giving black pawn a white pawn to feed
       final MoveSpecification move = new MoveSpecification(G2, G4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2067,7 +2067,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // giving white pawn a black pawn to feed
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2087,7 +2087,7 @@ class TestPotentialToSquares implements EnumConstants {
       // supported in potential to level
       // now looking at the a-pawn
       final MoveSpecification move = new MoveSpecification(A2, A4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2105,7 +2105,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black captures the offered pawn
       final MoveSpecification move = new MoveSpecification(F5, G4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2123,7 +2123,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white offers the en passant capture
       final MoveSpecification move = new MoveSpecification(H2, H4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2141,7 +2141,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black captures en passant
       final MoveSpecification move = new MoveSpecification(G4, H3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2159,7 +2159,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white further a-pawn advance
       final MoveSpecification move = new MoveSpecification(A4, A5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2177,7 +2177,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black allows en passant capture
       final MoveSpecification move = new MoveSpecification(B7, B5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2195,7 +2195,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white captures en passant
       final MoveSpecification move = new MoveSpecification(A5, B6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2213,7 +2213,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black pushes h-pawn
       final MoveSpecification move = new MoveSpecification(H3, H2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2231,7 +2231,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white captures zig-zag for promotion - zig
       final MoveSpecification move = new MoveSpecification(B6, A7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2249,7 +2249,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black promotes to queen by capturing
       final MoveSpecification move = new MoveSpecification(H2, G1, PromotionPieceType.QUEEN);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2268,7 +2268,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white promotes to queen by capturing - zag
       final MoveSpecification move = new MoveSpecification(A7, B8, PromotionPieceType.QUEEN);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // we check the queen
@@ -2287,7 +2287,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black prepares offering rook for capturing by pawn
       final MoveSpecification move = new MoveSpecification(A8, A5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // we check the queen
@@ -2307,7 +2307,7 @@ class TestPotentialToSquares implements EnumConstants {
       // white does the same with the knight
       // we start focusing the capturing pawns now
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2325,7 +2325,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black offers the rook
       final MoveSpecification move = new MoveSpecification(A5, B5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2343,7 +2343,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // the pawn takes it
       final MoveSpecification move = new MoveSpecification(C4, B5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2361,7 +2361,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black attacks the pawn with a pawn
       final MoveSpecification move = new MoveSpecification(C7, C6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2379,7 +2379,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white offers the knight to a pawn
       final MoveSpecification move = new MoveSpecification(C3, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2397,7 +2397,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black captures the knight
       final MoveSpecification move = new MoveSpecification(D5, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2415,7 +2415,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white offers en passant
       final MoveSpecification move = new MoveSpecification(D2, D4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2433,7 +2433,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black ignores en passant
       final MoveSpecification move = new MoveSpecification(E8, D7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2453,7 +2453,7 @@ class TestPotentialToSquares implements EnumConstants {
       // white starts to ignore en passant
       // we look at whites f-pawn now
       final MoveSpecification move = new MoveSpecification(F2, F4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2472,7 +2472,7 @@ class TestPotentialToSquares implements EnumConstants {
       // black ignores en passant capture possibility - but en passant not supported
       // in potential to level
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2491,7 +2491,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white f-pawn goes ahead
       final MoveSpecification move = new MoveSpecification(F4, F5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2509,7 +2509,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // black offers en passant capture
       final MoveSpecification move = new MoveSpecification(G7, G5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final Set<Square> potentialToSquareSet = PawnPotentialToSquares.calculatePawnPotentialToSquares(
@@ -2527,7 +2527,7 @@ class TestPotentialToSquares implements EnumConstants {
     {
       // white ignores en passant capture
       final MoveSpecification move = new MoveSpecification(B2, B3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // en passant capture right is gone

--- a/src/test/java/com/dlb/chess/test/fen/TestFenConstants.java
+++ b/src/test/java/com/dlb/chess/test/fen/TestFenConstants.java
@@ -25,9 +25,9 @@ class TestFenConstants {
     final Set<String> calculatedFenSet = new TreeSet<>();
     final ChessBoard board = new Board();
     for (final MoveSpecification moveSpecification : board.getPossibleMoveSpecificationSet()) {
-      board.performMove(moveSpecification);
+      board.move(moveSpecification);
       calculatedFenSet.add(board.getFen());
-      board.unperformMove();
+      board.unmove();
     }
 
     // third we compare them and expect to be equal

--- a/src/test/java/com/dlb/chess/test/fen/TestFenGeneration.java
+++ b/src/test/java/com/dlb/chess/test/fen/TestFenGeneration.java
@@ -19,41 +19,41 @@ class TestFenGeneration {
     check(FenConstants.FEN_INITIAL_STR, board);
 
     // some position - white to move
-    board.performMoves("Nc3", "Nc6");
+    board.movesStrict("Nc3", "Nc6");
     check("r1bqkbnr/pppppppp/2n5/8/8/2N5/PPPPPPPP/R1BQKBNR w KQkq - 2 2", board);
 
     // some position - black to move
-    board.performMove("Nf3");
+    board.moveStrict("Nf3");
     check("r1bqkbnr/pppppppp/2n5/8/8/2N2N2/PPPPPPPP/R1BQKB1R b KQkq - 3 2", board);
 
-    board.performMove("Nf6");
+    board.moveStrict("Nf6");
 
     // two square advance white
-    board.performMoves("e4");
+    board.movesStrict("e4");
     check("r1bqkb1r/pppppppp/2n2n2/8/4P3/2N2N2/PPPP1PPP/R1BQKB1R b KQkq e3 0 3", board);
 
     // two square advance black
-    board.performMoves("e5");
+    board.movesStrict("e5");
     check("r1bqkb1r/pppp1ppp/2n2n2/4p3/4P3/2N2N2/PPPP1PPP/R1BQKB1R w KQkq e6 0 4", board);
 
     // en passant target square does not stay
-    board.performMoves("a3");
+    board.movesStrict("a3");
     check("r1bqkb1r/pppp1ppp/2n2n2/4p3/4P3/P1N2N2/1PPP1PPP/R1BQKB1R b KQkq - 0 4", board);
 
     // white lost both castling rights
-    board.performMoves("a6", "Ke2");
+    board.movesStrict("a6", "Ke2");
     check("r1bqkb1r/1ppp1ppp/p1n2n2/4p3/4P3/P1N2N2/1PPPKPPP/R1BQ1B1R b kq - 1 5", board);
 
     // black lost both king side castling rights
-    board.performMoves("Rg8");
+    board.movesStrict("Rg8");
     check("r1bqkbr1/1ppp1ppp/p1n2n2/4p3/4P3/P1N2N2/1PPPKPPP/R1BQ1B1R w q - 2 6", board);
 
     // black lost queen side castling rights - so no more player has castling rights
-    board.performMoves("a4", "Rb8");
+    board.movesStrict("a4", "Rb8");
     check("1rbqkbr1/1ppp1ppp/p1n2n2/4p3/P3P3/2N2N2/1PPPKPPP/R1BQ1B1R w - - 1 7", board);
 
     // increase half-move clock to 20
-    board.performMoves("Ra2", "Ra8", "Ra3", "Ra7", "Rb3", "Ra8", "Rb4", "Rb8", "Rc4", "Ra8", "Rd4", "Rb8", "Rd5", "Ra8",
+    board.movesStrict("Ra2", "Ra8", "Ra3", "Ra7", "Rb3", "Ra8", "Rb4", "Rb8", "Rc4", "Ra8", "Rd4", "Rb8", "Rd5", "Ra8",
         "Rd6", "Rb8", "Rg1", "Ra8", "Rd5");
     check("r1bqkbr1/1ppp1ppp/p1n2n2/3Rp3/P3P3/2N2N2/1PPPKPPP/2BQ1BR1 b - - 20 16", board);
 

--- a/src/test/java/com/dlb/chess/test/fen/TestFenParserUsingBoard.java
+++ b/src/test/java/com/dlb/chess/test/fen/TestFenParserUsingBoard.java
@@ -30,7 +30,7 @@ class TestFenParserUsingBoard extends AbstractTestFenParser {
   void testAlongMovesExcludingHistory() {
     final ChessBoard boardMakeMoves = new Board();
 
-    boardMakeMoves.performMoves("d4", "d5", "Nc3", "Nf6", "Bf4", "a6", "e3", "b5", "Bd3", "e6", "Nf3", "c5", "O-O",
+    boardMakeMoves.movesStrict("d4", "d5", "Nc3", "Nf6", "Bf4", "a6", "e3", "b5", "Bd3", "e6", "Nf3", "c5", "O-O",
         "Bb7", "Ne5", "Nbd7", "a3", "Nxe5", "Bxe5", "Bd6", "f4", "O-O", "Qf3", "c4", "Be2", "Ne4", "Nxe4", "dxe4",
         "Qg4", "g6", "h4", "f5", "Qg3", "Bxe5", "fxe5", "Bd5", "c3", "a5", "Qh3", "h5", "Qg3", "Kh7", "Qg5", "Qxg5",
         "hxg5", "Rfb8", "Rfc1", "Ra7", "g3", "Kg7", "Kf2", "Kf7", "Ke1", "Ke7", "Kd2", "Rb6", "Ra2", "Rab7", "Raa1",
@@ -57,7 +57,7 @@ class TestFenParserUsingBoard extends AbstractTestFenParser {
   @Test
   void testAlongMovesIncludingHistory() {
     final ChessBoard boardMakeMoves = new Board();
-    boardMakeMoves.performMoves("e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "c3", "d6", "d4", "exd4", "cxd4", "Bxd4",
+    boardMakeMoves.movesStrict("e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "c3", "d6", "d4", "exd4", "cxd4", "Bxd4",
         "Nxd4", "Nxd4", "O-O", "Nf6", "Re1", "Nxe4", "Nc3", "O-O");
 
     final List<MoveSpecification> moveList = boardMakeMoves.getPerformedMoveSpecificationList();

--- a/src/test/java/com/dlb/chess/test/generate/GenerateAmbronaHelpMateTestCases.java
+++ b/src/test/java/com/dlb/chess/test/generate/GenerateAmbronaHelpMateTestCases.java
@@ -108,7 +108,7 @@ public class GenerateAmbronaHelpMateTestCases {
       // play the existing moves
       final Board board = new Board();
       for (final HalfMove halfMove : report.halfMoveList()) {
-        board.performMove(halfMove.moveSpecification());
+        board.move(halfMove.moveSpecification());
       }
 
       // play the helpmating moves
@@ -117,7 +117,7 @@ public class GenerateAmbronaHelpMateTestCases {
       for (@NonNull final String uciMoveStr : uciMoveStrList) {
         final UciMove uciMove = UciMoveValidationUtility.lookup(uciMoveStr);
         final MoveSpecification moveSpecification = UciMoveUtility.convertUciMoveToMoveSpecification(board, uciMove);
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
       }
 
       // write the file

--- a/src/test/java/com/dlb/chess/test/generate/GenerateChaTestCases.java
+++ b/src/test/java/com/dlb/chess/test/generate/GenerateChaTestCases.java
@@ -65,7 +65,7 @@ public class GenerateChaTestCases implements EnumConstants {
 
           for (final PgnHalfMove halfMove : pgnFile.halfMoveList()) {
             halfMoveCounter++;
-            board.performMove(halfMove.san());
+            board.moveStrict(halfMove.san());
 
             pw.println(calculateLine(board, folderPath, pgnFileName, halfMoveCounter));
 

--- a/src/test/java/com/dlb/chess/test/generate/GeneratePythonTestCases.java
+++ b/src/test/java/com/dlb/chess/test/generate/GeneratePythonTestCases.java
@@ -81,7 +81,7 @@ public class GeneratePythonTestCases implements EnumConstants {
 
         final ChessBoard boardPlayAlong = new Board();
         for (final HalfMove halfMove : report.halfMoveList()) {
-          boardPlayAlong.performMove(halfMove.moveSpecification());
+          boardPlayAlong.move(halfMove.moveSpecification());
           processPythonCodeLine("    board.push_san(\"" + halfMove.san() + "\")", counterList, codeLineList);
           final var isMadeByWhite = halfMove.havingMove().getIsWhite();
           if (isMadeByWhite && halfMove.fullMoveNumber() % PRINT_MOVES_INTERVAL == 0) {

--- a/src/test/java/com/dlb/chess/test/generate/GenerateRandomGame.java
+++ b/src/test/java/com/dlb/chess/test/generate/GenerateRandomGame.java
@@ -45,7 +45,7 @@ public class GenerateRandomGame {
       if (numberOfMoveOptions != 0) {
         final var randomMoveNumberIndex = RandomUtility.calculateRandomNumber(0, numberOfMoveOptions - 1);
         final MoveSpecification moveSpecification = NonNullWrapperCommon.get(moveOptionList, randomMoveNumberIndex);
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
         numberOfHalfMovesPerformed++;
         if (numberOfHalfMovesPerformed == 1 || numberOfHalfMovesPerformed % 100 == 0) {
           System.out.println("Number of half-moves performed: " + numberOfHalfMovesPerformed);
@@ -55,7 +55,7 @@ public class GenerateRandomGame {
 
       moveOptionList = new ArrayList<>();
       for (final MoveSpecification moveSpecification : legalMoveSet) {
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
         switch (findRandomGame) {
           case CHECKMATE:
             if (board.isCheckmate()) {
@@ -94,7 +94,7 @@ public class GenerateRandomGame {
             && !board.isFiftyMove()) {
           moveOptionList.add(moveSpecification);
         }
-        board.unperformMove();
+        board.unmove();
       }
       numberOfMoveOptions = moveOptionList.size();
     }
@@ -102,13 +102,13 @@ public class GenerateRandomGame {
     if (halfMoveNumberLastPossibleTermination != -1) {
       System.out.println("No more non terminating moves - we have a termination option");
       for (var i = numberOfHalfMovesPerformed; i >= halfMoveNumberLastPossibleTermination; i--) {
-        board.unperformMove();
+        board.unmove();
       }
       // now we should have at least one checkmate move
       // perform first found
       legalMoveSet = board.getPossibleMoveSpecificationSet();
       for (final MoveSpecification moveSpecification : legalMoveSet) {
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
 
         var isTerminationMoveFound = false;
         switch (findRandomGame) {
@@ -146,7 +146,7 @@ public class GenerateRandomGame {
           System.out.println(moveList);
           break;
         }
-        board.unperformMove();
+        board.unmove();
       }
     } else {
       System.out.println("No more non terminating moves - no termination option");
@@ -165,7 +165,7 @@ public class GenerateRandomGame {
       if (numberOfMoveOptions != 0) {
         final var randomMoveNumberIndex = RandomUtility.calculateRandomNumber(0, numberOfMoveOptions - 1);
         final MoveSpecification moveSpecification = NonNullWrapperCommon.get(moveOptionList, randomMoveNumberIndex);
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
         numberOfHalfMovesPerformed++;
         if (numberOfHalfMovesPerformed == 1 || numberOfHalfMovesPerformed % 100 == 0) {
           System.out.println("Number of half-moves performed: " + numberOfHalfMovesPerformed);
@@ -175,12 +175,12 @@ public class GenerateRandomGame {
 
       moveOptionList = new ArrayList<>();
       for (final MoveSpecification moveSpecification : legalMoveSet) {
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
         if (!board.isCheckmate() && !board.isStalemate()
             && board.isDeadPositionQuick() != DeadPositionQuick.DEAD_POSITION && board.getRepetitionCount() == 1) {
           moveOptionList.add(moveSpecification);
         }
-        board.unperformMove();
+        board.unmove();
       }
       numberOfMoveOptions = moveOptionList.size();
     }
@@ -205,7 +205,7 @@ public class GenerateRandomGame {
       if (numberOfMoveOptions != 0) {
         final var randomMoveNumberIndex = RandomUtility.calculateRandomNumber(0, numberOfMoveOptions - 1);
         final MoveSpecification moveSpecification = NonNullWrapperCommon.get(moveOptionList, randomMoveNumberIndex);
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
         if (!isFiftyReached && board.isFiftyMove()) {
           isFiftyReached = true;
           System.out.println("Reached fifty move");
@@ -227,13 +227,13 @@ public class GenerateRandomGame {
 
       moveOptionList = new ArrayList<>();
       for (final MoveSpecification moveSpecification : legalMoveSet) {
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
         if (!board.isCheckmate() && !board.isStalemate()
             && board.isDeadPositionQuick() == DeadPositionQuick.DEAD_POSITION && board.getRepetitionCount() == 1
             && (!isFiftyReached || board.isFiftyMove())) {
           moveOptionList.add(moveSpecification);
         }
-        board.unperformMove();
+        board.unmove();
       }
       numberOfMoveOptions = moveOptionList.size();
     }
@@ -275,7 +275,7 @@ public class GenerateRandomGame {
       {
         final var randomMoveNumberIndex = RandomUtility.calculateRandomNumber(0, numberOfMoveOptions - 1);
         final MoveSpecification moveSpecification = NonNullWrapperCommon.get(moveOptionList, randomMoveNumberIndex);
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
         if (!isRepetitionReached && board.getRepetitionCount() == 2) {
           isRepetitionReached = true;
           repetitionPosition = board.getDynamicPosition();
@@ -301,21 +301,21 @@ public class GenerateRandomGame {
       // try to speed up
       // if we find continuation we use it, otherwise we never hit more than three using random moves
       for (final MoveSpecification moveSpecification : legalMoveSet) {
-        board.performMove(moveSpecification);
+        board.move(moveSpecification);
         if (repetitionPosition.equals(board.getDynamicPosition())) {
           moveOptionList.add(moveSpecification);
         }
-        board.unperformMove();
+        board.unmove();
       }
       if (moveOptionList.isEmpty()) {
         // means we have no continuation from 3 onwards found
         for (final MoveSpecification moveSpecification : legalMoveSet) {
-          board.performMove(moveSpecification);
+          board.move(moveSpecification);
           if (!board.isCheckmate() && !board.isStalemate()
               && board.isDeadPositionQuick() == DeadPositionQuick.DEAD_POSITION && !board.isFiftyMove()) {
             moveOptionList.add(moveSpecification);
           }
-          board.unperformMove();
+          board.unmove();
         }
       }
       numberOfMoveOptions = moveOptionList.size();

--- a/src/test/java/com/dlb/chess/test/lan/TestLanCalculation.java
+++ b/src/test/java/com/dlb/chess/test/lan/TestLanCalculation.java
@@ -15,64 +15,64 @@ class TestLanCalculation implements EnumConstants {
   void test() {
     final ChessBoard board = new Board();
 
-    board.performMove("e4");
+    board.moveStrict("e4");
     assertEquals("e2e4", board.getLan());
 
-    board.performMove("d5");
+    board.moveStrict("d5");
     assertEquals("d7d5", board.getLan());
 
-    board.performMove("exd5");
+    board.moveStrict("exd5");
     assertEquals("e4xd5", board.getLan());
 
-    board.performMove("e5");
+    board.moveStrict("e5");
     assertEquals("e7e5", board.getLan());
 
-    board.performMove("dxe6");
+    board.moveStrict("dxe6");
     assertEquals("d5xe6", board.getLan());
 
-    board.performMove("h6");
+    board.moveStrict("h6");
     assertEquals("h7h6", board.getLan());
 
-    board.performMove("exf7+");
+    board.moveStrict("exf7+");
     assertEquals("e6xf7+", board.getLan());
 
-    board.performMove("Ke7");
+    board.moveStrict("Ke7");
     assertEquals("Ke8e7", board.getLan());
 
-    board.performMove("fxg8=Q");
+    board.moveStrict("fxg8=Q");
     assertEquals("f7xg8=Q", board.getLan());
 
-    board.performMove("h5");
+    board.moveStrict("h5");
     assertEquals("h6h5", board.getLan());
 
-    board.performMove("Qxh8");
+    board.moveStrict("Qxh8");
     assertEquals("Qg8xh8", board.getLan());
 
-    board.performMove("h4");
+    board.moveStrict("h4");
     assertEquals("h5h4", board.getLan());
 
-    board.performMove("g4");
+    board.moveStrict("g4");
     assertEquals("g2g4", board.getLan());
 
-    board.performMove("hxg3");
+    board.moveStrict("hxg3");
     assertEquals("h4xg3", board.getLan());
 
-    board.performMove("a4");
+    board.moveStrict("a4");
     assertEquals("a2a4", board.getLan());
 
-    board.performMove("gxh2");
+    board.moveStrict("gxh2");
     assertEquals("g3xh2", board.getLan());
 
-    board.performMove("a5");
+    board.moveStrict("a5");
     assertEquals("a4a5", board.getLan());
 
-    board.performMove("hxg1=Q");
+    board.moveStrict("hxg1=Q");
     assertEquals("h2xg1=Q", board.getLan());
 
-    board.performMove("a6");
+    board.moveStrict("a6");
     assertEquals("a5a6", board.getLan());
 
-    board.performMove("Qxh1");
+    board.moveStrict("Qxh1");
     assertEquals("Qg1xh1", board.getLan());
 
   }

--- a/src/test/java/com/dlb/chess/test/legalmoves/TestLegalMovesAgainstCreatedUsingValidation.java
+++ b/src/test/java/com/dlb/chess/test/legalmoves/TestLegalMovesAgainstCreatedUsingValidation.java
@@ -73,7 +73,7 @@ class TestLegalMovesAgainstCreatedUsingValidation {
     checkLegalMoves(board);
 
     for (final PgnHalfMove halfMove : pgnFile.halfMoveList()) {
-      board.performMove(halfMove.san());
+      board.moveStrict(halfMove.san());
       checkLegalMoves(board);
     }
 

--- a/src/test/java/com/dlb/chess/test/legalmoves/TestLegalMovesForGames.java
+++ b/src/test/java/com/dlb/chess/test/legalmoves/TestLegalMovesForGames.java
@@ -976,7 +976,7 @@ class TestLegalMovesForGames {
   }
 
   private static void checkLegalMoves(ChessBoard board, String san, String expected) {
-    board.performMove(san);
+    board.moveStrict(san);
     final String actual = BasicUtility.calculateCommaSeparatedList(board.getLegalMovesSan());
     assertEquals(expected, actual);
   }
@@ -989,7 +989,7 @@ class TestLegalMovesForGames {
     final PgnFile pgnFile = PgnCacheForStrictPgnParserTestCases.getPgn(pgnTest.getFolderPath(), pgnFileName);
     final var board = new Board();
     for (final PgnHalfMove move : pgnFile.halfMoveList()) {
-      board.performMove(move.san());
+      board.moveStrict(move.san());
       final String san = board.getSan();
       final String legalMoveList = BasicUtility.calculateCommaSeparatedList(board.getLegalMovesSan());
       final var output = "checkLegalMoves(board, \"" + san + "\", \"" + legalMoveList + "\");";

--- a/src/test/java/com/dlb/chess/test/legalmoves/TestLegalMovesForPiecesLegalPosition.java
+++ b/src/test/java/com/dlb/chess/test/legalmoves/TestLegalMovesForPiecesLegalPosition.java
@@ -64,7 +64,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(A2, A4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -79,7 +79,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(H7, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -96,7 +96,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move rook out
       final MoveSpecification move = new MoveSpecification(A1, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -113,7 +113,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black rook moves out
       final MoveSpecification move = new MoveSpecification(H8, H6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -137,7 +137,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - prepare pin
       final MoveSpecification move = new MoveSpecification(D2, D3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -161,7 +161,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - prepare pin
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -180,7 +180,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // move rook in diagonal with own king
       final MoveSpecification move = new MoveSpecification(A3, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -204,7 +204,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move queen out - to later put in diagonal with white king
       final MoveSpecification move = new MoveSpecification(D8, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -225,7 +225,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // move pawn to let white light square bishop out
       final MoveSpecification move = new MoveSpecification(E2, E3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -245,7 +245,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move queen in diagonal with white king
       final MoveSpecification move = new MoveSpecification(D6, B4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -260,7 +260,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // d-pawn advance to take bishop out
       final MoveSpecification move = new MoveSpecification(D3, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -284,7 +284,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black retreats queen
       final MoveSpecification move = new MoveSpecification(B4, A5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -299,7 +299,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // take bishop out
       final MoveSpecification move = new MoveSpecification(F1, B5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -315,7 +315,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black blocks check with rook
       final MoveSpecification move = new MoveSpecification(H6, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -330,7 +330,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // moves rook out of diagonal
       final MoveSpecification move = new MoveSpecification(E1, E2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -345,7 +345,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves king out of diagonal
       final MoveSpecification move = new MoveSpecification(E8, D8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -366,7 +366,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // moves previously pinned rook to attack the queen
       final MoveSpecification move = new MoveSpecification(C3, B3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -392,7 +392,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black guards the queen :-)
       final MoveSpecification move = new MoveSpecification(C6, B6);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -431,7 +431,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves knight out
       final MoveSpecification move = new MoveSpecification(B1, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -448,7 +448,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves knight out
       final MoveSpecification move = new MoveSpecification(G8, F6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -466,7 +466,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white offers black knight a pawn
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -486,7 +486,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black knight captures the pawn
       final MoveSpecification move = new MoveSpecification(F6, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -504,7 +504,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves knight into center
       final MoveSpecification move = new MoveSpecification(A3, C4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -527,7 +527,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black knight captures the pawn
       final MoveSpecification move = new MoveSpecification(A7, A5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -548,7 +548,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white knight takes the pawn
       final MoveSpecification move = new MoveSpecification(C4, A5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -571,7 +571,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black put knight in king diagonal
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -590,7 +590,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves knight away so black can gift the rook
       final MoveSpecification move = new MoveSpecification(A5, B3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -613,7 +613,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves out rook so can be captured
       final MoveSpecification move = new MoveSpecification(A8, A5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -631,7 +631,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white knight captures the rook
       final MoveSpecification move = new MoveSpecification(B3, A5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -652,7 +652,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves pawn to open king diagonal
       final MoveSpecification move = new MoveSpecification(D7, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -671,7 +671,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves queen out to be captured
       final MoveSpecification move = new MoveSpecification(D1, G4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -693,7 +693,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black makes an "escape" square for king
       final MoveSpecification move = new MoveSpecification(E7, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -712,7 +712,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves bishop out
       final MoveSpecification move = new MoveSpecification(F1, B5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -727,7 +727,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves king out of diagonal
       final MoveSpecification move = new MoveSpecification(E8, E7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -746,7 +746,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white offers queen to knight
       final MoveSpecification move = new MoveSpecification(G4, G3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -767,7 +767,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black knight takes the queen
       final MoveSpecification move = new MoveSpecification(E4, G3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -785,7 +785,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white knight on g1 to e2 for later ping
       final MoveSpecification move = new MoveSpecification(G1, E2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -806,7 +806,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king out of the way for black queen
       final MoveSpecification move = new MoveSpecification(E7, D7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -826,7 +826,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // let other white knight capture a pawn
       final MoveSpecification move = new MoveSpecification(A5, B7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -847,7 +847,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black queen to f6
       final MoveSpecification move = new MoveSpecification(D8, F6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -867,7 +867,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // let other white knight capture another pawn
       final MoveSpecification move = new MoveSpecification(B7, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -888,7 +888,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black queen into line with white queen
       final MoveSpecification move = new MoveSpecification(F6, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -903,7 +903,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white king moves out of file with black queen
       final MoveSpecification move = new MoveSpecification(E1, D1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -924,7 +924,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black knight captures white rook
       final MoveSpecification move = new MoveSpecification(G3, H1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -944,7 +944,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // king establishes pin again by moving back
       final MoveSpecification move = new MoveSpecification(D1, E1);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -981,7 +981,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white open square for white dark squares bishop
       final MoveSpecification move = new MoveSpecification(D2, D3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -996,7 +996,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black open square for black light squares bishop
       final MoveSpecification move = new MoveSpecification(D7, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1016,7 +1016,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move bishop out
       final MoveSpecification move = new MoveSpecification(C1, H6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1036,7 +1036,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves bishop out
       final MoveSpecification move = new MoveSpecification(C8, D7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1057,7 +1057,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move knight out
       final MoveSpecification move = new MoveSpecification(G1, F3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1079,7 +1079,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves knight out
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1100,7 +1100,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves knight towards own bishop
       final MoveSpecification move = new MoveSpecification(F3, H4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1119,7 +1119,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // opens square for black king
       final MoveSpecification move = new MoveSpecification(E7, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1140,7 +1140,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves knight next to bishop
       final MoveSpecification move = new MoveSpecification(H4, G6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1155,7 +1155,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black queen goes to the right
       final MoveSpecification move = new MoveSpecification(D8, C8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1176,7 +1176,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white knight now blocks a few bishop fields
       final MoveSpecification move = new MoveSpecification(G6, F4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1190,7 +1190,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king goes out
       final MoveSpecification move = new MoveSpecification(E8, E7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1207,7 +1207,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white king goes for a walk
       final MoveSpecification move = new MoveSpecification(E1, D2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1222,7 +1222,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king continues walk
       final MoveSpecification move = new MoveSpecification(E7, F6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1239,7 +1239,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white king continues walk
       final MoveSpecification move = new MoveSpecification(D2, E3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1254,7 +1254,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // knight out of the way
       final MoveSpecification move = new MoveSpecification(C6, B8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1271,7 +1271,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white queen enters the game
       final MoveSpecification move = new MoveSpecification(D1, D2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1290,7 +1290,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black bishop in line with own king
       final MoveSpecification move = new MoveSpecification(D7, B5);
-      board.performMove(move);
+      board.move(move);
     }
 
     // two more
@@ -1307,7 +1307,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     }
     {
       final MoveSpecification move = new MoveSpecification(E3, F3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1329,7 +1329,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king moves in line with queen
       final MoveSpecification move = new MoveSpecification(F6, F5);
-      board.performMove(move);
+      board.move(move);
     }
     // two more
 
@@ -1347,7 +1347,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white queen pins the black bishop
       final MoveSpecification move = new MoveSpecification(D2, A5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1362,7 +1362,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king moves out of line - breaks the pin
       final MoveSpecification move = new MoveSpecification(F5, F6);
-      board.performMove(move);
+      board.move(move);
     }
 
     // two more moves
@@ -1380,7 +1380,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white bishop checks black king
       final MoveSpecification move = new MoveSpecification(H6, G5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1395,7 +1395,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king moves to the side
       final MoveSpecification move = new MoveSpecification(F6, E5);
-      board.performMove(move);
+      board.move(move);
     }
     // two more moves
 
@@ -1416,7 +1416,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves knight out of the way of bishop
       final MoveSpecification move = new MoveSpecification(F4, H3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1430,7 +1430,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     }
     {
       final MoveSpecification move = new MoveSpecification(C8, D8);
-      board.performMove(move);
+      board.move(move);
     }
 
     // two more moves
@@ -1455,7 +1455,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves knight out of the way of bishop
       final MoveSpecification move = new MoveSpecification(H1, G1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black bishop possible moves - pinned
@@ -1469,7 +1469,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black queen enters the game and checks the white king
       final MoveSpecification move = new MoveSpecification(D8, F6);
-      board.performMove(move);
+      board.move(move);
     }
     // two more moves
 
@@ -1487,7 +1487,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white bishop moves before king for check
       final MoveSpecification move = new MoveSpecification(G5, F4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1502,7 +1502,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king moves out of check
       final MoveSpecification move = new MoveSpecification(E5, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1516,7 +1516,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     }
     {
       final MoveSpecification move = new MoveSpecification(G1, H1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1531,7 +1531,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king breaks the pin
       final MoveSpecification move = new MoveSpecification(D5, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1546,7 +1546,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white king moves out of line with black queen - breaking the pin
       final MoveSpecification move = new MoveSpecification(F3, G3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1565,7 +1565,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black bishop goes to edge of the board
       final MoveSpecification move = new MoveSpecification(B5, A4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1587,7 +1587,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white bishop captures a pawn now
       final MoveSpecification move = new MoveSpecification(F4, D6);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -1625,7 +1625,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves a central pawn
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1640,7 +1640,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves a central pawn
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1659,7 +1659,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves queen out
       final MoveSpecification move = new MoveSpecification(D1, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1676,7 +1676,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves queen out
       final MoveSpecification move = new MoveSpecification(D8, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1705,7 +1705,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white crashes queen in
       final MoveSpecification move = new MoveSpecification(H5, H7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1736,7 +1736,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves bishop out
       final MoveSpecification move = new MoveSpecification(C8, H3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1760,7 +1760,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white crashes queen in
       final MoveSpecification move = new MoveSpecification(F1, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1791,7 +1791,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves knight out
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1815,7 +1815,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white retreats queen a bit
       final MoveSpecification move = new MoveSpecification(H7, F5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1843,7 +1843,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black moves queeen to crush in on white king later...
       final MoveSpecification move = new MoveSpecification(D6, B4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1873,7 +1873,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white queen rushes in to black king
       final MoveSpecification move = new MoveSpecification(F5, F7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1889,7 +1889,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king moves out of check
       final MoveSpecification move = new MoveSpecification(E8, D8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1917,7 +1917,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white queen captures a knight
       final MoveSpecification move = new MoveSpecification(F7, G8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1946,7 +1946,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black queen crushes in on white king
       final MoveSpecification move = new MoveSpecification(B4, D2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1962,7 +1962,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white king moves away
       final MoveSpecification move = new MoveSpecification(E1, F1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -1992,7 +1992,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black queen takes a pawn
       final MoveSpecification move = new MoveSpecification(D2, C2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2014,7 +2014,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white queen takes the rook, finally...
       final MoveSpecification move = new MoveSpecification(G8, H8);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -2053,7 +2053,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white pawn one square advance
       final MoveSpecification move = new MoveSpecification(E2, E3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2070,7 +2070,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black pawn one square advance
       final MoveSpecification move = new MoveSpecification(D7, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2087,7 +2087,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white pawn two squares advance
       final MoveSpecification move = new MoveSpecification(D2, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2104,7 +2104,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black pawn two squares advance
       final MoveSpecification move = new MoveSpecification(F7, F5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2120,7 +2120,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white pawn one squares advance
       final MoveSpecification move = new MoveSpecification(D4, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2137,7 +2137,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black pawn two squares advance so white can capture en passant
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2153,7 +2153,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white pawn - en passant capture
       final MoveSpecification move = new MoveSpecification(D5, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2169,7 +2169,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black pawn advance so can capture en passant later
       final MoveSpecification move = new MoveSpecification(F5, F4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2186,7 +2186,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white pawn two square advance to allow black en passant capture
       final MoveSpecification move = new MoveSpecification(G2, G4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2204,7 +2204,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black en passant capture
       final MoveSpecification move = new MoveSpecification(F4, G3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2220,7 +2220,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white pawn goes for promotion
       final MoveSpecification move = new MoveSpecification(E6, E7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2238,7 +2238,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black pawn goes for promotion
       final MoveSpecification move = new MoveSpecification(G3, G2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2261,7 +2261,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white pawn promotes to queen
       final MoveSpecification move = new MoveSpecification(E7, D8, PromotionPieceType.QUEEN);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2276,7 +2276,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black captures promoted pawn
       final MoveSpecification move = new MoveSpecification(E8, D8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2293,7 +2293,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white moves another pawn
       final MoveSpecification move = new MoveSpecification(A2, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2316,7 +2316,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black now promotes the pawn
       final MoveSpecification move = new MoveSpecification(G2, F1, PromotionPieceType.KNIGHT);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2331,17 +2331,17 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white captures the promoted knight
       final MoveSpecification move = new MoveSpecification(E1, F1);
-      board.performMove(move);
+      board.move(move);
     }
 
     // we now create a position where a black pawn is pinned against moving forward
     {
       final MoveSpecification move = new MoveSpecification(D8, D7);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(D1, D4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black pawn can move forward
@@ -2355,11 +2355,11 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     }
     {
       final MoveSpecification move = new MoveSpecification(D7, E6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(D4, B6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black pawn is pinned
@@ -2373,12 +2373,12 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king moves out of line with queen
       final MoveSpecification move = new MoveSpecification(E6, F7);
-      board.performMove(move);
+      board.move(move);
     }
     // white moves queen on same rank
     {
       final MoveSpecification move = new MoveSpecification(B6, A6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black pawn now unpinned
@@ -2393,36 +2393,36 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black king moves back to e8
       final MoveSpecification move = new MoveSpecification(F7, E8);
-      board.performMove(move);
+      board.move(move);
     }
 
     // we now create a position where white pawn cannot capture en passant for own
     // king would be in check
     {
       final MoveSpecification move = new MoveSpecification(F2, F4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(F8, E7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(F4, F5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(G8, H6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       final MoveSpecification move = new MoveSpecification(F1, F2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(H8, F8);
-      board.performMove(move);
+      board.move(move);
     }
 
     // white pawn can move forward
@@ -2437,11 +2437,11 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     }
     {
       final MoveSpecification move = new MoveSpecification(F2, F3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(G7, G5);
-      board.performMove(move);
+      board.move(move);
     }
     // white pawn can move forward but not capture en passant for being pinned
     {
@@ -2455,11 +2455,11 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     }
     {
       final MoveSpecification move = new MoveSpecification(F3, F2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       final MoveSpecification move = new MoveSpecification(F8, G8);
-      board.performMove(move);
+      board.move(move);
     }
     // white pawn can move forward but not capture en passant even it not pinned
     // anymore, as en passant capture right is gone
@@ -2474,7 +2474,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     }
     {
       final MoveSpecification move = new MoveSpecification(F5, F6);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -2532,7 +2532,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2547,7 +2547,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2563,7 +2563,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(E1, E2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2579,7 +2579,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(E8, E7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2598,7 +2598,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(E2, E3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2617,7 +2617,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(E7, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2635,7 +2635,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(E3, D3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2653,7 +2653,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(E6, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2672,7 +2672,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D3, C4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2690,7 +2690,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D6, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2710,13 +2710,13 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
       final MoveSpecification move = new MoveSpecification(C4, C5);
       // check
       assertThrows(InvalidMoveException.class, () -> {
-        board.performMove(move);
+        board.move(move);
       });
     }
     {
       // white move valid
       final MoveSpecification move = new MoveSpecification(C4, B3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2736,13 +2736,13 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
       final MoveSpecification move = new MoveSpecification(C6, D5);
       // check
       assertThrows(InvalidMoveException.class, () -> {
-        board.performMove(move);
+        board.move(move);
       });
     }
     {
       // black move valid
       final MoveSpecification move = new MoveSpecification(C6, B6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2760,7 +2760,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // prepares check
       final MoveSpecification move = new MoveSpecification(D1, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2778,7 +2778,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // prepares check
       final MoveSpecification move = new MoveSpecification(D8, H4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2796,7 +2796,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // checks
       final MoveSpecification move = new MoveSpecification(H5, H6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2813,7 +2813,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // blocks check with pawn
       final MoveSpecification move = new MoveSpecification(C7, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2831,7 +2831,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // captures pawn
       final MoveSpecification move = new MoveSpecification(H6, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2848,7 +2848,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // king takes queen
       final MoveSpecification move = new MoveSpecification(B6, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2866,7 +2866,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // pawn towards queen
       final MoveSpecification move = new MoveSpecification(H2, H3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2885,7 +2885,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // king takes pawn and checks
       final MoveSpecification move = new MoveSpecification(H4, H3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2902,7 +2902,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // block with knight
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2921,7 +2921,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // queen takes knight
       final MoveSpecification move = new MoveSpecification(H3, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2938,7 +2938,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // king takes queen
       final MoveSpecification move = new MoveSpecification(B3, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2957,7 +2957,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // queen takes knight
       final MoveSpecification move = new MoveSpecification(C6, B6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2975,7 +2975,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // king takes queen
       final MoveSpecification move = new MoveSpecification(C3, B3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -2994,7 +2994,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // takes knight out
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3012,7 +3012,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // bishop to black king
       final MoveSpecification move = new MoveSpecification(F1, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3031,7 +3031,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // bishop to black king
       final MoveSpecification move = new MoveSpecification(F8, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3050,7 +3050,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // bishop to black king
       final MoveSpecification move = new MoveSpecification(C2, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3069,7 +3069,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // bishop takes a pawn
       final MoveSpecification move = new MoveSpecification(A3, B2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3088,7 +3088,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white king towards black king
       final MoveSpecification move = new MoveSpecification(B3, A4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3106,7 +3106,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // king takes the bishop
       final MoveSpecification move = new MoveSpecification(B6, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3122,7 +3122,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // bishop takes bishop
       final MoveSpecification move = new MoveSpecification(C1, B2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3138,7 +3138,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // a silly rook move for the end
       final MoveSpecification move = new MoveSpecification(A8, B8);
-      board.performMove(move);
+      board.move(move);
     }
 
   }
@@ -3157,7 +3157,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3172,7 +3172,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3188,7 +3188,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D2, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3204,7 +3204,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3221,7 +3221,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(F1, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3238,7 +3238,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(F8, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3256,7 +3256,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(G1, H3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3274,7 +3274,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(G8, H6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3293,7 +3293,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(A6, D3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3312,7 +3312,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(A3, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3331,7 +3331,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(F2, F4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3350,7 +3350,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(F7, F5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3370,7 +3370,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D1, H5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3388,7 +3388,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - blocks check with pawn
       final MoveSpecification move = new MoveSpecification(G7, G6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3409,7 +3409,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D3, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3429,7 +3429,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - blocks check with pawn
       final MoveSpecification move = new MoveSpecification(D8, H4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3448,7 +3448,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - blocks check with pawn
       final MoveSpecification move = new MoveSpecification(G2, G3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3469,7 +3469,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D6, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3490,7 +3490,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - blocks black castling with bishop - step 1
       final MoveSpecification move = new MoveSpecification(A6, C4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3511,7 +3511,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - blocks white castling with bishop - step 1
       final MoveSpecification move = new MoveSpecification(A3, C5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3532,7 +3532,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - blocks black castling with bishop - step 2
       final MoveSpecification move = new MoveSpecification(C4, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3551,7 +3551,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - blocks white castling with bishop - step 2
       final MoveSpecification move = new MoveSpecification(C5, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3570,7 +3570,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - bishop makes harakiri
       final MoveSpecification move = new MoveSpecification(D5, B7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3591,7 +3591,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - castling kingside
       final MoveSpecification move = new MoveSpecification(CastlingMove.KING_SIDE);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3610,7 +3610,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - bishop takes rook
       final MoveSpecification move = new MoveSpecification(B7, A8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3629,7 +3629,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - bishop makes harakiri
       final MoveSpecification move = new MoveSpecification(D4, B2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3650,7 +3650,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - castling kingside
       final MoveSpecification move = new MoveSpecification(CastlingMove.KING_SIDE);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3669,7 +3669,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - bishop takes the rook
       final MoveSpecification move = new MoveSpecification(B2, A1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3687,7 +3687,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - castling happened kingside
       final MoveSpecification move = new MoveSpecification(G1, H1);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -3705,7 +3705,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3720,7 +3720,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3736,7 +3736,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D2, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3752,7 +3752,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3769,7 +3769,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(B1, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3786,7 +3786,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(B8, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3803,7 +3803,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(C2, C4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3820,7 +3820,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(C7, C5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3837,7 +3837,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D1, B3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3854,7 +3854,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D8, B6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3872,7 +3872,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(C1, D2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3890,7 +3890,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(C8, D7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3908,7 +3908,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D2, E3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3926,7 +3926,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D7, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3945,7 +3945,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - check black king
       final MoveSpecification move = new MoveSpecification(B3, A4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3962,7 +3962,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - moves bishop into check
       final MoveSpecification move = new MoveSpecification(E6, D7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3981,7 +3981,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - queen "sacrifice"
       final MoveSpecification move = new MoveSpecification(A4, A6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -3999,7 +3999,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - checks
       final MoveSpecification move = new MoveSpecification(B6, A5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4016,7 +4016,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - bishop blocks check
       final MoveSpecification move = new MoveSpecification(E3, D2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4034,7 +4034,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - queen "sacrifice"
       final MoveSpecification move = new MoveSpecification(A5, A3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4052,7 +4052,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - bishop to block black castling
       final MoveSpecification move = new MoveSpecification(D2, G5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4067,7 +4067,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - bishop to block white castling
       final MoveSpecification move = new MoveSpecification(D7, G4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4083,7 +4083,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - bring out knight to allow castling
       final MoveSpecification move = new MoveSpecification(G1, E2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4099,7 +4099,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - bring out knight to allow castling
       final MoveSpecification move = new MoveSpecification(G8, E7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4117,7 +4117,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - castling
       final MoveSpecification move = new MoveSpecification(CastlingMove.QUEEN_SIDE);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4135,7 +4135,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - castling
       final MoveSpecification move = new MoveSpecification(CastlingMove.QUEEN_SIDE);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -4144,32 +4144,32 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // white move
       final MoveSpecification move = new MoveSpecification(G1, F3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(G8, F6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // white move
       final MoveSpecification move = new MoveSpecification(F1, C4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(F8, C5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // white king possible moves - castling possible king side
@@ -4186,7 +4186,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - king side castling gone by rook move
       final MoveSpecification move = new MoveSpecification(H1, F1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black king possible moves - castling possible king side
@@ -4203,7 +4203,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - king side castling gone by rook move
       final MoveSpecification move = new MoveSpecification(H8, F8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // white king possible moves
@@ -4218,7 +4218,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - rook moves back
       final MoveSpecification move = new MoveSpecification(F1, H1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black king possible moves
@@ -4233,7 +4233,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - rook moves back
       final MoveSpecification move = new MoveSpecification(F8, H8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4250,7 +4250,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - knight out
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4267,7 +4267,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - knight out
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -4276,32 +4276,32 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // white move
       final MoveSpecification move = new MoveSpecification(G1, F3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(G8, F6);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // white move
       final MoveSpecification move = new MoveSpecification(F1, C4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(F8, C5);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // white king possible moves - castling possible king side
@@ -4318,7 +4318,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - king side castling gone by king move
       final MoveSpecification move = new MoveSpecification(E1, F1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black king possible moves - castling possible king side
@@ -4335,7 +4335,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - king side castling gone by king move
       final MoveSpecification move = new MoveSpecification(E8, F8);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // white king possible moves
@@ -4352,7 +4352,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - king moves back
       final MoveSpecification move = new MoveSpecification(F1, E1);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black king possible moves
@@ -4369,7 +4369,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - king moves back
       final MoveSpecification move = new MoveSpecification(F8, E8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4386,7 +4386,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - knight out
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4403,7 +4403,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - knight out
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -4412,56 +4412,56 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(B2, B3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(B7, B6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(C1, B2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(C8, B7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D2, D3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D7, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D1, D2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D8, D7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4478,7 +4478,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - move queenside rook away
       final MoveSpecification move = new MoveSpecification(A1, D1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4495,7 +4495,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - move queenside rook away
       final MoveSpecification move = new MoveSpecification(A8, D8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4510,7 +4510,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - move queenside rook back
       final MoveSpecification move = new MoveSpecification(D1, A1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4525,7 +4525,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - move queenside rook back
       final MoveSpecification move = new MoveSpecification(D8, A8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4541,7 +4541,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - move knight out
       final MoveSpecification move = new MoveSpecification(G1, F3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4557,7 +4557,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - move knight out
       final MoveSpecification move = new MoveSpecification(G8, F6);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -4566,45 +4566,45 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D2, D4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(C1, F4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(C8, F5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D1, D3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D8, D6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4622,7 +4622,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - move king away
       final MoveSpecification move = new MoveSpecification(E1, D1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4640,7 +4640,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - move king away
       final MoveSpecification move = new MoveSpecification(E8, D8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4658,7 +4658,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - move king back
       final MoveSpecification move = new MoveSpecification(D1, E1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4676,7 +4676,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - move king back
       final MoveSpecification move = new MoveSpecification(D8, E8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4693,7 +4693,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - develop knight
       final MoveSpecification move = new MoveSpecification(G1, F3);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4710,7 +4710,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - develop knight
       final MoveSpecification move = new MoveSpecification(G8, F6);
-      board.performMove(move);
+      board.move(move);
     }
   }
 
@@ -4719,34 +4719,34 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move
       final MoveSpecification move = new MoveSpecification(E2, E4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(E7, E5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(G1, F3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(G8, F6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(F1, C4);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(F8, C5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4764,7 +4764,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - prepare queen side castling
       final MoveSpecification move = new MoveSpecification(D2, D4);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4782,40 +4782,40 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - prepare queen side castling
       final MoveSpecification move = new MoveSpecification(D7, D5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(B1, C3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(B8, C6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(C1, E3);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(C8, E6);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
       // white move
       final MoveSpecification move = new MoveSpecification(D1, E2);
-      board.performMove(move);
+      board.move(move);
     }
     {
       // black move
       final MoveSpecification move = new MoveSpecification(D8, E7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4835,7 +4835,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - moves king away
       final MoveSpecification move = new MoveSpecification(E1, D2);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4855,7 +4855,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - moves king away
       final MoveSpecification move = new MoveSpecification(E8, D7);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4874,7 +4874,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - moves king back
       final MoveSpecification move = new MoveSpecification(D2, E1);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4893,7 +4893,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - moves king back
       final MoveSpecification move = new MoveSpecification(D7, E8);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4911,7 +4911,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // white move - moves knight
       final MoveSpecification move = new MoveSpecification(F3, G5);
-      board.performMove(move);
+      board.move(move);
     }
 
     {
@@ -4929,7 +4929,7 @@ class TestLegalMovesForPiecesLegalPosition implements EnumConstants {
     {
       // black move - moves knight
       final MoveSpecification move = new MoveSpecification(F6, G4);
-      board.performMove(move);
+      board.move(move);
     }
   }
 

--- a/src/test/java/com/dlb/chess/test/librarycarlos/board/LibraryCarlosBoard.java
+++ b/src/test/java/com/dlb/chess/test/librarycarlos/board/LibraryCarlosBoard.java
@@ -66,7 +66,7 @@ public class LibraryCarlosBoard implements ChessBoard {
   }
 
   @Override
-  public boolean performMove(MoveSpecification moveSpecification) {
+  public boolean move(MoveSpecification moveSpecification) {
     final Side havingMove = getHavingMove();
     final var result = board.doMove(MoveConversionUtility.convertMoveSpecification(havingMove, moveSpecification));
     populateMoveHistory(moveSpecification);
@@ -74,12 +74,21 @@ public class LibraryCarlosBoard implements ChessBoard {
   }
 
   @Override
-  public boolean performMove(String san) {
-
-    final var result = board.doMove(san);
+  public com.dlb.chess.san.model.StrictSanParserValidationResult moveStrict(String san) {
+    board.doMove(san);
     final MoveSpecification lastMoveSpecification = calculateLastMoveSpecification();
     populateMoveHistory(lastMoveSpecification);
-    return result;
+    return new com.dlb.chess.san.model.StrictSanParserValidationResult(lastMoveSpecification);
+  }
+
+  @Override
+  public com.dlb.chess.san.model.LenientSanParserValidationResult moveLenient(String san) {
+    // Carlos's chesslib doesn't have a lenient SAN concept; delegate to strict, then wrap into the lenient result
+    // shape with empty forgiven items. Cross-validation tests only need the move to land on the board.
+    final com.dlb.chess.san.model.StrictSanParserValidationResult strict = moveStrict(san);
+    return new com.dlb.chess.san.model.LenientSanParserValidationResult(strict.moveSpecification(),
+        com.dlb.chess.common.NonNullWrapperCommon
+            .copyOfList(java.util.List.<com.dlb.chess.san.model.ForgivenItem>of()));
   }
 
   private MoveSpecification calculateLastMoveSpecification() {
@@ -115,7 +124,7 @@ public class LibraryCarlosBoard implements ChessBoard {
   }
 
   @Override
-  public void unperformMove() {
+  public void unmove() {
     board.undoMove();
 
     performedHalfMoveCount--;
@@ -146,12 +155,12 @@ public class LibraryCarlosBoard implements ChessBoard {
   @Override
   public boolean canClaimThreefoldRepetitionRuleWithOwnMove() {
     for (final MoveSpecification moveSpecification : getPossibleMoveSpecificationSet()) {
-      performMove(moveSpecification);
+      move(moveSpecification);
       if (isThreefoldRepetition()) {
-        unperformMove();
+        unmove();
         return true;
       }
-      unperformMove();
+      unmove();
     }
     return false;
   }
@@ -564,12 +573,12 @@ public class LibraryCarlosBoard implements ChessBoard {
   }
 
   @Override
-  public boolean performMoves(String... sanArray) {
+  public boolean movesStrict(String... sanArray) {
     for (final String san : sanArray) {
       if (san == null) {
         throw new IllegalArgumentException();
       }
-      this.performMove(san);
+      this.moveStrict(san);
     }
     return true;
   }

--- a/src/test/java/com/dlb/chess/test/librarycarlos/board/LibraryCarlosBoard.java
+++ b/src/test/java/com/dlb/chess/test/librarycarlos/board/LibraryCarlosBoard.java
@@ -16,10 +16,10 @@ import com.dlb.chess.board.enums.Piece;
 import com.dlb.chess.board.enums.Side;
 import com.dlb.chess.board.enums.Square;
 import com.dlb.chess.common.NonNullWrapperCommon;
-import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.common.constants.ChessConstants;
 import com.dlb.chess.common.constants.DynamicPositionConstants;
 import com.dlb.chess.common.exceptions.ProgrammingMistakeException;
+import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.common.model.DynamicPosition;
 import com.dlb.chess.common.model.HalfMove;
 import com.dlb.chess.common.model.MoveSpecification;
@@ -33,8 +33,6 @@ import com.dlb.chess.san.enums.SanSymbol;
 import com.dlb.chess.san.enums.SanTerminalMarker;
 import com.dlb.chess.test.librarycarlos.NonNullWrapperLibraryCarlos;
 import com.dlb.chess.test.librarycarlos.utility.MoveConversionUtility;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.dlb.chess.test.librarycomparison.utility.BoardConversionUtitlity;
 import com.dlb.chess.test.librarycomparison.utility.EnumConversionUtility;
 import com.github.bhlangonijr.chesslib.Board;
@@ -45,6 +43,8 @@ import com.github.bhlangonijr.chesslib.move.MoveConversionException;
 import com.github.bhlangonijr.chesslib.move.MoveGenerator;
 import com.github.bhlangonijr.chesslib.move.MoveGeneratorException;
 import com.github.bhlangonijr.chesslib.move.MoveList;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class LibraryCarlosBoard implements ChessBoard {
 
@@ -476,7 +476,8 @@ public class LibraryCarlosBoard implements ChessBoard {
     for (final MoveBackup moveBackup : moveBackupList) {
       final Move move = NonNullWrapperLibraryCarlos.getMove(moveBackup);
       final MoveSpecification moveSpecification = convertMove(board, move);
-      final Piece movingPiece = EnumConversionUtility.convertPiece(NonNullWrapperLibraryCarlos.getMovingPiece(moveBackup));
+      final Piece movingPiece = EnumConversionUtility
+          .convertPiece(NonNullWrapperLibraryCarlos.getMovingPiece(moveBackup));
       final Piece pieceCaptured = EnumConversionUtility
           .convertPiece(NonNullWrapperLibraryCarlos.getCapturedPiece(moveBackup));
       final LegalMove legalMove = new LegalMove(moveSpecification, movingPiece, pieceCaptured);
@@ -578,6 +579,17 @@ public class LibraryCarlosBoard implements ChessBoard {
         throw new IllegalArgumentException();
       }
       this.moveStrict(san);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean movesLenient(String... sanArray) {
+    for (final String san : sanArray) {
+      if (san == null) {
+        throw new IllegalArgumentException();
+      }
+      this.moveLenient(san);
     }
     return true;
   }

--- a/src/test/java/com/dlb/chess/test/librarycarlos/board/LibraryCarlosBoard.java
+++ b/src/test/java/com/dlb/chess/test/librarycarlos/board/LibraryCarlosBoard.java
@@ -87,8 +87,7 @@ public class LibraryCarlosBoard implements ChessBoard {
     // shape with empty forgiven items. Cross-validation tests only need the move to land on the board.
     final com.dlb.chess.san.model.StrictSanParserValidationResult strict = moveStrict(san);
     return new com.dlb.chess.san.model.LenientSanParserValidationResult(strict.moveSpecification(),
-        com.dlb.chess.common.NonNullWrapperCommon
-            .copyOfList(java.util.List.<com.dlb.chess.san.model.ForgivenItem>of()));
+        com.dlb.chess.san.model.ForgivenItem.EMPTY_LIST);
   }
 
   private MoveSpecification calculateLastMoveSpecification() {

--- a/src/test/java/com/dlb/chess/test/librarycomparison/allpgn/TestBoardAgainstEachOther.java
+++ b/src/test/java/com/dlb/chess/test/librarycomparison/allpgn/TestBoardAgainstEachOther.java
@@ -62,8 +62,8 @@ class TestBoardAgainstEachOther {
         for (final PgnHalfMove pgnFileHalfMove : pgnFile.halfMoveList()) {
 
           final String san = pgnFileHalfMove.san();
-          board.performMove(san);
-          carlosBoard.performMove(san);
+          board.moveStrict(san);
+          carlosBoard.moveStrict(san);
 
           CommonTestUtility.checkBoardsAgainstEachOtherAll(board, carlosBoard);
 

--- a/src/test/java/com/dlb/chess/test/pgn/export/TestPgnExportBoard.java
+++ b/src/test/java/com/dlb/chess/test/pgn/export/TestPgnExportBoard.java
@@ -36,7 +36,7 @@ class TestPgnExportBoard {
     final Board boardExpected = new Board();
     for (final String san : sanArray) {
       @SuppressWarnings("null") @NonNull final String sanIsNotNull = san;
-      boardExpected.performMove(sanIsNotNull);
+      boardExpected.moveStrict(sanIsNotNull);
     }
 
     final PgnFile boardExpectedPgnFile = PgnCreate.createPgnFile(boardExpected);

--- a/src/test/java/com/dlb/chess/test/pgn/parser/AbstractTestPgnParserHalfMoveClockFromFen.java
+++ b/src/test/java/com/dlb/chess/test/pgn/parser/AbstractTestPgnParserHalfMoveClockFromFen.java
@@ -64,7 +64,7 @@ abstract class AbstractTestPgnParserHalfMoveClockFromFen {
 
         final ChessBoard board = new Board(pgnFile.startFen());
         for (final PgnHalfMove halfMove : pgnFile.halfMoveList()) {
-          board.performMove(halfMove.san());
+          board.moveStrict(halfMove.san());
         }
 
         try {

--- a/src/test/java/com/dlb/chess/test/pgn/parser/TestLenientPgnParserSanForgivenItems.java
+++ b/src/test/java/com/dlb/chess/test/pgn/parser/TestLenientPgnParserSanForgivenItems.java
@@ -16,8 +16,8 @@ import com.dlb.chess.test.pgntest.constants.PgnTestConstants;
 
 /**
  * One fixture per {@link LenientSanValidationProblem} value. Each fixture is a minimal lenient PGN whose movetext
- * contains exactly one move with the named deviation; the rest of the moves (if any) are canonical SAN. The lenient
- * PGN parser must accept the fixture and surface exactly the expected forgiven code.
+ * contains exactly one move with the named deviation; the rest of the moves (if any) are canonical SAN. The lenient PGN
+ * parser must accept the fixture and surface exactly the expected forgiven code.
  */
 @SuppressWarnings("static-method")
 class TestLenientPgnParserSanForgivenItems {
@@ -146,7 +146,7 @@ class TestLenientPgnParserSanForgivenItems {
         "Expected valid lenient parse of " + fixtureFileName + " but got: " + result.message());
     assertEquals(1, result.sanForgivenItems().size(),
         "Expected exactly one forgiven item in " + fixtureFileName + " but got: " + result.sanForgivenItems());
-    final ForgivenItem item = result.sanForgivenItems().get(0);
+    final ForgivenItem item = NonNullWrapperCommon.get(result.sanForgivenItems(), 0);
     assertEquals(expectedCode, item.code(),
         "Expected forgiven code " + expectedCode + " in " + fixtureFileName + " but got: " + item.code());
   }

--- a/src/test/java/com/dlb/chess/test/pgn/parser/TestLenientPgnParserSanForgivenItems.java
+++ b/src/test/java/com/dlb/chess/test/pgn/parser/TestLenientPgnParserSanForgivenItems.java
@@ -1,0 +1,153 @@
+package com.dlb.chess.test.pgn.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import com.dlb.chess.common.NonNullWrapperCommon;
+import com.dlb.chess.pgn.parser.LenientPgnParser;
+import com.dlb.chess.pgn.parser.model.LenientPgnParserValidationResult;
+import com.dlb.chess.san.enums.LenientSanValidationProblem;
+import com.dlb.chess.san.model.ForgivenItem;
+import com.dlb.chess.test.pgntest.constants.PgnTestConstants;
+
+/**
+ * One fixture per {@link LenientSanValidationProblem} value. Each fixture is a minimal lenient PGN whose movetext
+ * contains exactly one move with the named deviation; the rest of the moves (if any) are canonical SAN. The lenient
+ * PGN parser must accept the fixture and surface exactly the expected forgiven code.
+ */
+@SuppressWarnings("static-method")
+class TestLenientPgnParserSanForgivenItems {
+
+  private static final Path FOLDER = NonNullWrapperCommon
+      .pathResolve(PgnTestConstants.LENIENT_PGN_PARSER_TEST_ROOT_FOLDER_PATH, "sanForgivenItems");
+
+  @Test
+  void test01_missingCheckSuffix() {
+    assertExactlyOneCode("01_missing_check_suffix.pgn", LenientSanValidationProblem.MISSING_CHECK_SUFFIX);
+  }
+
+  @Test
+  void test02_missingCheckmateSuffix() {
+    assertExactlyOneCode("02_missing_checkmate_suffix.pgn", LenientSanValidationProblem.MISSING_CHECKMATE_SUFFIX);
+  }
+
+  @Test
+  void test03_spuriousCheckSuffix() {
+    assertExactlyOneCode("03_spurious_check_suffix.pgn", LenientSanValidationProblem.SPURIOUS_CHECK_SUFFIX);
+  }
+
+  @Test
+  void test04_spuriousCheckmateSuffix() {
+    assertExactlyOneCode("04_spurious_checkmate_suffix.pgn", LenientSanValidationProblem.SPURIOUS_CHECKMATE_SUFFIX);
+  }
+
+  @Test
+  void test05_wrongCheckSuffixForCheckmate() {
+    assertExactlyOneCode("05_wrong_check_suffix_for_checkmate.pgn",
+        LenientSanValidationProblem.WRONG_CHECK_SUFFIX_FOR_CHECKMATE);
+  }
+
+  @Test
+  void test06_wrongCheckmateSuffixForCheck() {
+    assertExactlyOneCode("06_wrong_checkmate_suffix_for_check.pgn",
+        LenientSanValidationProblem.WRONG_CHECKMATE_SUFFIX_FOR_CHECK);
+  }
+
+  @Test
+  void test07_missingCaptureMarker() {
+    assertExactlyOneCode("07_missing_capture_marker.pgn", LenientSanValidationProblem.MISSING_CAPTURE_MARKER);
+  }
+
+  @Test
+  void test08_spuriousCaptureMarker() {
+    assertExactlyOneCode("08_spurious_capture_marker.pgn", LenientSanValidationProblem.SPURIOUS_CAPTURE_MARKER);
+  }
+
+  @Test
+  void test09_overspecifiedFileDisambiguation() {
+    assertExactlyOneCode("09_overspecified_file_disambiguation.pgn",
+        LenientSanValidationProblem.OVERSPECIFIED_FILE_DISAMBIGUATION);
+  }
+
+  @Test
+  void test10_overspecifiedRankDisambiguation() {
+    assertExactlyOneCode("10_overspecified_rank_disambiguation.pgn",
+        LenientSanValidationProblem.OVERSPECIFIED_RANK_DISAMBIGUATION);
+  }
+
+  @Test
+  void test11_overspecifiedSquareDisambiguation() {
+    assertExactlyOneCode("11_overspecified_square_disambiguation.pgn",
+        LenientSanValidationProblem.OVERSPECIFIED_SQUARE_DISAMBIGUATION);
+  }
+
+  @Test
+  void test12_nonStandardRankDisambiguation() {
+    assertExactlyOneCode("12_non_standard_rank_disambiguation.pgn",
+        LenientSanValidationProblem.NON_STANDARD_RANK_DISAMBIGUATION);
+  }
+
+  @Test
+  void test13_longAlgebraicNotation() {
+    assertExactlyOneCode("13_long_algebraic_notation.pgn", LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION);
+  }
+
+  @Test
+  void test14_uciNotation() {
+    assertExactlyOneCode("14_uci_notation.pgn", LenientSanValidationProblem.UCI_NOTATION);
+  }
+
+  @Test
+  void test15_zeroInsteadOfOCastling() {
+    assertExactlyOneCode("15_zero_instead_of_o_castling.pgn", LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING);
+  }
+
+  @Test
+  void test16_explicitPawnLetter() {
+    assertExactlyOneCode("16_explicit_pawn_letter.pgn", LenientSanValidationProblem.EXPLICIT_PAWN_LETTER);
+  }
+
+  @Test
+  void test17_missingPromotionEquals() {
+    assertExactlyOneCode("17_missing_promotion_equals.pgn", LenientSanValidationProblem.MISSING_PROMOTION_EQUALS);
+  }
+
+  @Test
+  void test18_lowercasePieceLetter() {
+    assertExactlyOneCode("18_lowercase_piece_letter.pgn", LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
+  }
+
+  @Test
+  void test19_uppercaseFileLetter() {
+    assertExactlyOneCode("19_uppercase_file_letter.pgn", LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
+  }
+
+  @Test
+  void test20_uppercaseCaptureMarker() {
+    assertExactlyOneCode("20_uppercase_capture_marker.pgn", LenientSanValidationProblem.UPPERCASE_CAPTURE_MARKER);
+  }
+
+  @Test
+  void test21_lowercasePromotionPiece() {
+    assertExactlyOneCode("21_lowercase_promotion_piece.pgn", LenientSanValidationProblem.LOWERCASE_PROMOTION_PIECE);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helper.
+  // ---------------------------------------------------------------------------
+
+  private static void assertExactlyOneCode(String fixtureFileName, LenientSanValidationProblem expectedCode) {
+    final LenientPgnParserValidationResult result = LenientPgnParser.validate(FOLDER, fixtureFileName);
+    assertTrue(result.isValid(),
+        "Expected valid lenient parse of " + fixtureFileName + " but got: " + result.message());
+    assertEquals(1, result.sanForgivenItems().size(),
+        "Expected exactly one forgiven item in " + fixtureFileName + " but got: " + result.sanForgivenItems());
+    final ForgivenItem item = result.sanForgivenItems().get(0);
+    assertEquals(expectedCode, item.code(),
+        "Expected forgiven code " + expectedCode + " in " + fixtureFileName + " but got: " + item.code());
+  }
+}

--- a/src/test/java/com/dlb/chess/test/pgn/parser/TestStrictPgnParserFromCustomPosition.java
+++ b/src/test/java/com/dlb/chess/test/pgn/parser/TestStrictPgnParserFromCustomPosition.java
@@ -68,13 +68,13 @@ class TestStrictPgnParserFromCustomPosition {
     final ChessBoard boardFromFen = new Board(pgnFile.startFen());
 
     for (final PgnHalfMove halfMove : pgnFile.halfMoveList()) {
-      boardFromFen.performMove(halfMove.san());
+      boardFromFen.moveStrict(halfMove.san());
     }
 
     final ChessBoard boardFromFirstMove = new Board();
     for (final String san : hardCodedCompleteSanList) {
       @SuppressWarnings("null") @NonNull final String nonNullSan = san;
-      boardFromFirstMove.performMove(nonNullSan);
+      boardFromFirstMove.moveStrict(nonNullSan);
     }
 
     CommonTestUtility.checkBoardsAgainstEachOtherExcludeHistory(boardFromFirstMove, boardFromFen);

--- a/src/test/java/com/dlb/chess/test/pgn/parser/TestStrictPgnParserFromInitialPosition.java
+++ b/src/test/java/com/dlb/chess/test/pgn/parser/TestStrictPgnParserFromInitialPosition.java
@@ -68,13 +68,13 @@ class TestStrictPgnParserFromInitialPosition {
     final Board actual = new Board();
 
     for (final PgnHalfMove halfMove : pgnFile.halfMoveList()) {
-      actual.performMove(halfMove.san());
+      actual.moveStrict(halfMove.san());
     }
 
     final Board expected = new Board();
     for (final String san : sanList) {
       @SuppressWarnings("null") @NonNull final String nonNullSan = san;
-      expected.performMove(nonNullSan);
+      expected.moveStrict(nonNullSan);
     }
 
     assertEquals(expected, actual);

--- a/src/test/java/com/dlb/chess/test/pgn/writer/package-info.java
+++ b/src/test/java/com/dlb/chess/test/pgn/writer/package-info.java
@@ -1,0 +1,4 @@
+@NonNullByDefault
+package com.dlb.chess.test.pgn.writer;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/src/test/java/com/dlb/chess/test/pgnall/TestFenParserAll.java
+++ b/src/test/java/com/dlb/chess/test/pgnall/TestFenParserAll.java
@@ -55,7 +55,7 @@ class TestFenParserAll extends AbstractTestFenParser {
 
     final ChessBoard board = new Board(pgnFile.startFen());
     for (final PgnHalfMove halfMove : pgnFile.halfMoveList()) {
-      board.performMove(halfMove.san());
+      board.moveStrict(halfMove.san());
     }
     final List<MoveSpecification> moveList = board.getPerformedMoveSpecificationList();
     checkGames(pgnFile.startFen().fen(), moveList, false);

--- a/src/test/java/com/dlb/chess/test/pgnall/TestInsufficientMaterial.java
+++ b/src/test/java/com/dlb/chess/test/pgnall/TestInsufficientMaterial.java
@@ -61,7 +61,7 @@ class TestInsufficientMaterial implements EnumConstants {
     final PgnFile pgnFile = PgnCacheForStrictPgnParserTestCases.getPgn(folderPath, pgnFileName);
     final ChessBoard boardFromFen = new Board(pgnFile.startFen());
     for (final PgnHalfMove halfMove : pgnFile.halfMoveList()) {
-      boardFromFen.performMove(halfMove.san());
+      boardFromFen.moveStrict(halfMove.san());
     }
 
     final var isInsufficientMaterialDirectlyCalculated = calculateIsInsufficientMaterial(

--- a/src/test/java/com/dlb/chess/test/pgntest/basic/AbstractTestBasic.java
+++ b/src/test/java/com/dlb/chess/test/pgntest/basic/AbstractTestBasic.java
@@ -125,16 +125,16 @@ public abstract class AbstractTestBasic implements EnumConstants {
     assertFalse(board.isStalemate());
 
     final LegalMove lastMoveEnPassantCapture = board.getLastMove();
-    board.unperformMove();
+    board.unmove();
 
     final LegalMove secondLastMoveTwoSquareAdvance = board.getLastMove();
-    board.unperformMove();
+    board.unmove();
 
-    board.performMove(secondLastMoveTwoSquareAdvance.moveSpecification());
+    board.move(secondLastMoveTwoSquareAdvance.moveSpecification());
     assertFalse(calculateIsEnPassantCaptureLastMove(board));
     assertEquals(toSquare, board.getEnPassantCaptureTargetSquare());
 
-    board.performMove(lastMoveEnPassantCapture.moveSpecification());
+    board.move(lastMoveEnPassantCapture.moveSpecification());
     assertTrue(calculateIsEnPassantCaptureLastMove(board));
     assertEquals(Square.NONE, board.getEnPassantCaptureTargetSquare());
 

--- a/src/test/java/com/dlb/chess/test/readme/TestReadMe.java
+++ b/src/test/java/com/dlb/chess/test/readme/TestReadMe.java
@@ -133,15 +133,15 @@ class TestReadMe {
   void boardExampleEndsInCheckmate() {
     final Board board = new Board();
 
-    board.performMove("e4");
-    board.performMoves("e5", "Bc4");
+    board.moveStrict("e4");
+    board.movesStrict("e5", "Bc4");
 
     final var newMove = new MoveSpecification(Square.F8, Square.C5);
-    board.performMove(newMove);
+    board.move(newMove);
 
-    board.unperformMove();
+    board.unmove();
 
-    board.performMoves("Bc5", "Qf3", "h6", "Qxf7#");
+    board.movesStrict("Bc5", "Qf3", "h6", "Qxf7#");
 
     assertTrue(board.isCheckmate());
   }
@@ -177,7 +177,7 @@ class TestReadMe {
 
     final PgnFile pgnFile = LenientPgnParser.parseText(pgn);
     final Board board = PgnUtility.calculateBoardPerLastMove(pgnFile);
-    board.performMove("a3");
+    board.moveStrict("a3");
 
     assertEquals("Spring Classic", tagValue(pgnFile, "Event"));
     assertEquals(6, pgnFile.halfMoveList().size());
@@ -244,7 +244,7 @@ class TestReadMe {
 
     final PgnFile pgnFile = StrictPgnParser.parseText(pgn);
     final Board board = PgnUtility.calculateBoardPerLastMove(pgnFile);
-    board.performMove("a3");
+    board.moveStrict("a3");
 
     assertEquals(6, pgnFile.halfMoveList().size());
   }
@@ -394,7 +394,7 @@ class TestReadMe {
 
   private static Board createOpeningExampleBoard() {
     final Board board = new Board();
-    board.performMoves("e4", "e5", "Nf3", "Nf6", "Bc4", "Bc5");
+    board.movesStrict("e4", "e5", "Nf3", "Nf6", "Bc4", "Bc5");
     return board;
   }
 

--- a/src/test/java/com/dlb/chess/test/readme/TestReadMe.java
+++ b/src/test/java/com/dlb/chess/test/readme/TestReadMe.java
@@ -342,13 +342,13 @@ class TestReadMe {
     assertTrue(result.isValid());
     assertEquals(2, result.sanForgivenItems().size());
     assertEquals(com.dlb.chess.san.enums.LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING,
-        result.sanForgivenItems().get(0).code());
-    assertEquals("0-0", result.sanForgivenItems().get(0).originalToken());
-    assertEquals("O-O", result.sanForgivenItems().get(0).canonicalSan());
+        NonNullWrapperCommon.get(result.sanForgivenItems(), 0).code());
+    assertEquals("0-0", NonNullWrapperCommon.get(result.sanForgivenItems(), 0).originalToken());
+    assertEquals("O-O", NonNullWrapperCommon.get(result.sanForgivenItems(), 0).canonicalSan());
     assertEquals(com.dlb.chess.san.enums.LenientSanValidationProblem.LOWERCASE_PIECE_LETTER,
-        result.sanForgivenItems().get(1).code());
-    assertEquals("nf6", result.sanForgivenItems().get(1).originalToken());
-    assertEquals("Nf6", result.sanForgivenItems().get(1).canonicalSan());
+        NonNullWrapperCommon.get(result.sanForgivenItems(), 1).code());
+    assertEquals("nf6", NonNullWrapperCommon.get(result.sanForgivenItems(), 1).originalToken());
+    assertEquals("Nf6", NonNullWrapperCommon.get(result.sanForgivenItems(), 1).canonicalSan());
   }
 
   @Test

--- a/src/test/java/com/dlb/chess/test/readme/TestReadMe.java
+++ b/src/test/java/com/dlb/chess/test/readme/TestReadMe.java
@@ -315,13 +315,40 @@ class TestReadMe {
 
         1. e4 e5   2. Nf3
         Nf6
-          3. Bc4 Bc5 4. X1
+          3. Bc4 Bc5 4. Y1
                 """;
     final LenientPgnParserValidationResult invalidResult = LenientPgnParser.validateText(invalidPgn);
     assertFalse(invalidResult.isValid());
     assertEquals(LenientPgnParserValidationProblem.EXCEPTION_CAUGHT_FROM_STRICT_VALIDATION,
         invalidResult.problemParser());
     assertEquals(SanValidationProblem.NONE, invalidResult.problemSan());
+  }
+
+  @Test
+  @SuppressWarnings("static-method")
+  void lenientPgnSanTolerancesExampleReturnsExpectedForgivenItems() {
+    final var pgn = """
+        [Event "?"]
+        [Site "?"]
+        [Date "?"]
+        [Round "?"]
+        [White "?"]
+        [Black "?"]
+        [Result "*"]
+
+        1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. 0-0 nf6 *
+                """;
+    final LenientPgnParserValidationResult result = LenientPgnParser.validateText(pgn);
+    assertTrue(result.isValid());
+    assertEquals(2, result.sanForgivenItems().size());
+    assertEquals(com.dlb.chess.san.enums.LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING,
+        result.sanForgivenItems().get(0).code());
+    assertEquals("0-0", result.sanForgivenItems().get(0).originalToken());
+    assertEquals("O-O", result.sanForgivenItems().get(0).canonicalSan());
+    assertEquals(com.dlb.chess.san.enums.LenientSanValidationProblem.LOWERCASE_PIECE_LETTER,
+        result.sanForgivenItems().get(1).code());
+    assertEquals("nf6", result.sanForgivenItems().get(1).originalToken());
+    assertEquals("Nf6", result.sanForgivenItems().get(1).canonicalSan());
   }
 
   @Test

--- a/src/test/java/com/dlb/chess/test/san/AbstractTestSanValidate.java
+++ b/src/test/java/com/dlb/chess/test/san/AbstractTestSanValidate.java
@@ -7,7 +7,7 @@ import com.dlb.chess.common.constants.EnumConstants;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 public abstract class AbstractTestSanValidate implements EnumConstants {
 
@@ -38,7 +38,7 @@ public abstract class AbstractTestSanValidate implements EnumConstants {
   private static void checkException(String san, ChessBoard board, SanValidationProblem problem) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/TestPerformMoveForSan.java
+++ b/src/test/java/com/dlb/chess/test/san/TestPerformMoveForSan.java
@@ -10,7 +10,7 @@ import com.dlb.chess.board.enums.PromotionPieceType;
 import com.dlb.chess.common.constants.EnumConstants;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.common.model.MoveSpecification;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestPerformMoveForSan implements EnumConstants {
 
@@ -25,43 +25,43 @@ class TestPerformMoveForSan implements EnumConstants {
 
       // we require checks in SAN to be real checks
       // we do not allow fake checks white
-      board.performMove("e4");
+      board.moveStrict("e4");
       // we do not allow fake checks black
-      board.performMove("e5");
-      board.performMove("Bc4");
-      board.performMove("Bc5");
+      board.moveStrict("e5");
+      board.moveStrict("Bc4");
+      board.moveStrict("Bc5");
       // real check white
-      board.performMove("Bxf7+");
-      board.performMove("Ke7");
-      board.performMove("a3");
+      board.moveStrict("Bxf7+");
+      board.moveStrict("Ke7");
+      board.moveStrict("a3");
       // real check black
-      board.performMove("Bxf2+");
-      board.performMove("Ke2");
+      board.moveStrict("Bxf2+");
+      board.moveStrict("Ke2");
 
       // we require checkmate in SAN to be real checkmate
       // we do not allow fake checkmate white
-      board.performMove("a6");
-      board.performMove("d3");
+      board.moveStrict("a6");
+      board.moveStrict("d3");
       // we do not allow fake checkmate black
-      board.performMove("Bc5");
-      board.performMove("Bc4");
-      board.performMove("Ke8");
-      board.performMove("Ke1");
-      board.performMove("a5");
-      board.performMove("Qf3");
-      board.performMove("a4");
+      board.moveStrict("Bc5");
+      board.moveStrict("Bc4");
+      board.moveStrict("Ke8");
+      board.moveStrict("Ke1");
+      board.moveStrict("a5");
+      board.moveStrict("Qf3");
+      board.moveStrict("a4");
       // real checkmate white
-      board.performMove("Qf7#");
+      board.moveStrict("Qf7#");
 
       // real checkmate black
       {
         final ChessBoard boardCheckmateBlack = new Board();
 
-        boardCheckmateBlack.performMove("f3");
-        boardCheckmateBlack.performMove("e5");
-        boardCheckmateBlack.performMove("g4");
+        boardCheckmateBlack.moveStrict("f3");
+        boardCheckmateBlack.moveStrict("e5");
+        boardCheckmateBlack.moveStrict("g4");
         // real checkmate black
-        boardCheckmateBlack.performMove("Qh4#");
+        boardCheckmateBlack.moveStrict("Qh4#");
       }
     } catch (@SuppressWarnings("unused") final Exception e) {
       isException = true;
@@ -117,33 +117,33 @@ class TestPerformMoveForSan implements EnumConstants {
       {
         final ChessBoard board = new Board();
 
-        board.performMoves("a4", "a5", "h4", "h5", "Ra3", "Ra6");
+        board.movesStrict("a4", "a5", "h4", "h5", "Ra3", "Ra6");
         // valid file specification white
-        board.performMoves("Rhh3");
+        board.movesStrict("Rhh3");
         // valid file specification black
-        board.performMoves("Rhh6");
+        board.movesStrict("Rhh6");
         // valid file specification white
-        board.performMoves("Rhe3");
+        board.movesStrict("Rhe3");
         // valid file specification black
-        board.performMoves("Rhe6");
+        board.movesStrict("Rhe6");
         // valid file specification white
-        board.performMoves("Rad3");
+        board.movesStrict("Rad3");
         // valid file specification black
-        board.performMoves("Rad6");
-        board.performMoves("Rd4");
-        board.performMoves("Rd5");
+        board.movesStrict("Rad6");
+        board.movesStrict("Rd4");
+        board.movesStrict("Rd5");
         // valid file specification white
-        board.performMoves("Rde4");
+        board.movesStrict("Rde4");
         // valid file specification black
-        board.performMoves("Red6");
-        board.performMoves("Re5");
-        board.performMoves("Rd4");
+        board.movesStrict("Red6");
+        board.movesStrict("Re5");
+        board.movesStrict("Rd4");
         // valid rank specification white
-        board.performMoves("R3e4");
-        board.performMoves("Rd3");
-        board.performMoves("Re6");
+        board.movesStrict("R3e4");
+        board.movesStrict("Rd3");
+        board.movesStrict("Re6");
         // valid rank specification white
-        board.performMoves("R6d5");
+        board.movesStrict("R6d5");
       }
 
       // knight
@@ -153,25 +153,25 @@ class TestPerformMoveForSan implements EnumConstants {
       {
         final ChessBoard board = new Board();
 
-        board.performMoves("Nc3", "Nc6", "Nh3", "Nh6", "Nf4", "Nf5");
+        board.movesStrict("Nc3", "Nc6", "Nh3", "Nh6", "Nf4", "Nf5");
         // valid file specification white
-        board.performMoves("Nfd5");
+        board.movesStrict("Nfd5");
         // valid file specification black
-        board.performMoves("Nfd4");
-        board.performMoves("Nb4", "Nb5", "Nd3", "Nd6", "Nc5", "Nc4");
+        board.movesStrict("Nfd4");
+        board.movesStrict("Nb4", "Nb5", "Nd3", "Nd6", "Nc5", "Nc4");
         // valid rank specification white
-        board.performMoves("N5e4");
+        board.movesStrict("N5e4");
         // valid rank specification black
-        board.performMoves("N4e5");
-        board.performMoves("h4", "a5", "h5", "a4", "h6", "a3", "hxg7", "axb2", "gxf8=N", "bxc1=N", "Ng5", "Ng4", "Nfe6",
+        board.movesStrict("N4e5");
+        board.movesStrict("h4", "a5", "h5", "a4", "h6", "a3", "hxg7", "axb2", "gxf8=N", "bxc1=N", "Ng5", "Ng4", "Nfe6",
             "Nb3");
-        board.performMoves("Nc5", "Nba5");
+        board.movesStrict("Nc5", "Nba5");
         // valid square specification white
-        board.performMoves("Nc5e4");
-        board.performMoves("Nc4");
-        board.performMoves("Nc5");
+        board.movesStrict("Nc5e4");
+        board.movesStrict("Nc4");
+        board.movesStrict("Nc5");
         // valid square specification black
-        board.performMoves("Nc4e5");
+        board.movesStrict("Nc4e5");
       }
 
       // bishop
@@ -184,26 +184,26 @@ class TestPerformMoveForSan implements EnumConstants {
       {
         final ChessBoard board = new Board();
 
-        board.performMoves("d4", "e5", "d5", "e4", "f3", "c6", "dxc6", "exf3", "cxb7", "fxg2", "bxa8=B", "gxh1=B", "e3",
+        board.movesStrict("d4", "e5", "d5", "e4", "f3", "c6", "dxc6", "exf3", "cxb7", "fxg2", "bxa8=B", "gxh1=B", "e3",
             "d6", "Bd5", "Bf3");
-        board.performMoves("Bb5+", "Ke7", "Bd2", "Bh3");
+        board.movesStrict("Bb5+", "Ke7", "Bd2", "Bh3");
         // valid file specification white
-        board.performMoves("Bbc6");
+        board.movesStrict("Bbc6");
         // valid file specification black
-        board.performMoves("Bfg4");
-        board.performMoves("Bc4", "Bg2");
+        board.movesStrict("Bfg4");
+        board.movesStrict("Bc4", "Bg2");
         // valid rank specification white
-        board.performMoves("B4d5");
+        board.movesStrict("B4d5");
         // valid rank specification black
-        board.performMoves("B2h3");
-        board.performMoves("e4", "a5", "e5", "a4", "e6", "a3");
-        board.performMoves("exf7", "axb2", "fxg8=B", "Qc8", "Na3", "b1=B", "Bc4", "Bxc2", "Bgd5", "Be4", "Be6", "Bf1");
+        board.movesStrict("B2h3");
+        board.movesStrict("e4", "a5", "e5", "a4", "e6", "a3");
+        board.movesStrict("exf7", "axb2", "fxg8=B", "Qc8", "Na3", "b1=B", "Bc4", "Bxc2", "Bgd5", "Be4", "Be6", "Bf1");
         // valid square specification white
-        board.performMoves("Bc6d5");
-        board.performMoves("Bfe2");
-        board.performMoves("Nb1");
+        board.movesStrict("Bc6d5");
+        board.movesStrict("Bfe2");
+        board.movesStrict("Nb1");
         // valid square specification black
-        board.performMoves("Be4f3");
+        board.movesStrict("Be4f3");
 
       }
 
@@ -214,27 +214,27 @@ class TestPerformMoveForSan implements EnumConstants {
       {
         final ChessBoard board = new Board();
 
-        board.performMoves("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=Q", "gxh1=Q", "Qb3", "e6");
+        board.movesStrict("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=Q", "gxh1=Q", "Qb3", "e6");
         // valid file specification white
-        board.performMoves("Qad5");
-        board.performMoves("Qg5");
-        board.performMoves("Qdc4");
-        board.performMoves("Qe4");
+        board.movesStrict("Qad5");
+        board.movesStrict("Qg5");
+        board.movesStrict("Qdc4");
+        board.movesStrict("Qe4");
         // valid file specification black
-        board.performMoves("Qcc3");
-        board.performMoves("Qgf4", "Qcb4", "Qfe5");
+        board.movesStrict("Qcc3");
+        board.movesStrict("Qgf4", "Qcb4", "Qfe5");
         // valid rank specification white
-        board.performMoves("Q3c4");
+        board.movesStrict("Q3c4");
         // valid rank specification black
-        board.performMoves("Q5f4");
-        board.performMoves("d4", "g5", "d5", "g4", "d6", "g3", "dxc7", "gxh2");
-        board.performMoves("cxb8=Q", "hxg1=Q", "Q8b5", "Qgg5");
+        board.movesStrict("Q5f4");
+        board.movesStrict("d4", "g5", "d5", "g4", "d6", "g3", "dxc7", "gxh2");
+        board.movesStrict("cxb8=Q", "hxg1=Q", "Q8b5", "Qgg5");
         // valid square specification white
-        board.performMoves("Qb4c5");
-        board.performMoves("Qef5");
-        board.performMoves("Qc5b4");
+        board.movesStrict("Qb4c5");
+        board.movesStrict("Qef5");
+        board.movesStrict("Qc5b4");
         // valid square specification black
-        board.performMoves("Qf5g4");
+        board.movesStrict("Qf5g4");
 
       }
     } catch (@SuppressWarnings("unused") final Exception e) {
@@ -245,10 +245,10 @@ class TestPerformMoveForSan implements EnumConstants {
   }
 
   private static void checkMoveSpecificationTest(ChessBoard board, String san, MoveSpecification expectedMove) {
-    final MoveSpecification parsedMoveAsIs = SanValidation.validateSan(san, board);
+    final MoveSpecification parsedMoveAsIs = StrictSanParser.parseText(san, board).moveSpecification();
     assertEquals(expectedMove, parsedMoveAsIs);
 
-    board.performMove(expectedMove);
+    board.move(expectedMove);
 
   }
 

--- a/src/test/java/com/dlb/chess/test/san/TestSanCalculation.java
+++ b/src/test/java/com/dlb/chess/test/san/TestSanCalculation.java
@@ -15,64 +15,64 @@ class TestSanCalculation implements EnumConstants {
   void test() {
     final ChessBoard board = new Board();
 
-    board.performMove("e4");
+    board.moveStrict("e4");
     assertEquals("e4", board.getSan());
 
-    board.performMove("d5");
+    board.moveStrict("d5");
     assertEquals("d5", board.getSan());
 
-    board.performMove("exd5");
+    board.moveStrict("exd5");
     assertEquals("exd5", board.getSan());
 
-    board.performMove("e5");
+    board.moveStrict("e5");
     assertEquals("e5", board.getSan());
 
-    board.performMove("dxe6");
+    board.moveStrict("dxe6");
     assertEquals("dxe6", board.getSan());
 
-    board.performMove("h6");
+    board.moveStrict("h6");
     assertEquals("h6", board.getSan());
 
-    board.performMove("exf7+");
+    board.moveStrict("exf7+");
     assertEquals("exf7+", board.getSan());
 
-    board.performMove("Ke7");
+    board.moveStrict("Ke7");
     assertEquals("Ke7", board.getSan());
 
-    board.performMove("fxg8=Q");
+    board.moveStrict("fxg8=Q");
     assertEquals("fxg8=Q", board.getSan());
 
-    board.performMove("h5");
+    board.moveStrict("h5");
     assertEquals("h5", board.getSan());
 
-    board.performMove("Qxh8");
+    board.moveStrict("Qxh8");
     assertEquals("Qxh8", board.getSan());
 
-    board.performMove("h4");
+    board.moveStrict("h4");
     assertEquals("h4", board.getSan());
 
-    board.performMove("g4");
+    board.moveStrict("g4");
     assertEquals("g4", board.getSan());
 
-    board.performMove("hxg3");
+    board.moveStrict("hxg3");
     assertEquals("hxg3", board.getSan());
 
-    board.performMove("a4");
+    board.moveStrict("a4");
     assertEquals("a4", board.getSan());
 
-    board.performMove("gxh2");
+    board.moveStrict("gxh2");
     assertEquals("gxh2", board.getSan());
 
-    board.performMove("a5");
+    board.moveStrict("a5");
     assertEquals("a5", board.getSan());
 
-    board.performMove("hxg1=Q");
+    board.moveStrict("hxg1=Q");
     assertEquals("hxg1=Q", board.getSan());
 
-    board.performMove("a6");
+    board.moveStrict("a6");
     assertEquals("a6", board.getSan());
 
-    board.performMove("Qxh1");
+    board.moveStrict("Qxh1");
     assertEquals("Qxh1", board.getSan());
 
   }

--- a/src/test/java/com/dlb/chess/test/san/TestSanValidateAgainstLegalMoves.java
+++ b/src/test/java/com/dlb/chess/test/san/TestSanValidateAgainstLegalMoves.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateAgainstLegalMoves {
 
@@ -19,7 +19,7 @@ class TestSanValidateAgainstLegalMoves {
     final ChessBoard board = new Board();
 
     // black
-    board.performMoves("e4");
+    board.movesStrict("e4");
     checkException(board, "Ke2", SanValidationProblem.NOT_REACHABLE_KING_NON_CASTLING);
     checkException(board, "Kxa1", SanValidationProblem.NOT_REACHABLE_KING_NON_CASTLING);
 
@@ -69,7 +69,7 @@ class TestSanValidateAgainstLegalMoves {
     checkException(board, "Qdd3", SanValidationProblem.NOT_REACHABLE_RNBQ_FILE_SINGLE);
 
     // black
-    board.performMoves("e4");
+    board.movesStrict("e4");
     // rook
     checkException(board, "Raa6", SanValidationProblem.NOT_REACHABLE_RNBQ_FILE_SINGLE);
 
@@ -91,25 +91,25 @@ class TestSanValidateAgainstLegalMoves {
 
     // white
     // rook
-    board.performMoves("a4");
-    board.performMoves("a5");
+    board.movesStrict("a4");
+    board.movesStrict("a5");
     checkException(board, "Raa2", SanValidationProblem.OVERSPECIFIED_RNBQ_FILE_ONLY_ONE_LEGAL_MOVE);
 
     // knight
     checkException(board, "Nbc3", SanValidationProblem.OVERSPECIFIED_RNBQ_FILE_ONLY_ONE_LEGAL_MOVE);
 
     // bishop
-    board.performMoves("b3");
-    board.performMoves("b6");
+    board.movesStrict("b3");
+    board.movesStrict("b6");
     checkException(board, "Bcb2", SanValidationProblem.OVERSPECIFIED_RNBQ_FILE_ONLY_ONE_LEGAL_MOVE);
 
     // queen
-    board.performMoves("d4");
-    board.performMoves("d5");
+    board.movesStrict("d4");
+    board.movesStrict("d5");
     checkException(board, "Qdd2", SanValidationProblem.OVERSPECIFIED_RNBQ_FILE_ONLY_ONE_LEGAL_MOVE);
 
     // black
-    board.performMoves("e4");
+    board.movesStrict("e4");
     // rook
     checkException(board, "Raa7", SanValidationProblem.OVERSPECIFIED_RNBQ_FILE_ONLY_ONE_LEGAL_MOVE);
 
@@ -129,7 +129,7 @@ class TestSanValidateAgainstLegalMoves {
   void testPieceFile2OnlyOneLegalMoveMore() {
 
     final ChessBoard board = new Board();
-    board.performMoves("e4", "e5", "d3", "Bb4+", "Nc3", "Nf6");
+    board.movesStrict("e4", "e5", "d3", "Bb4+", "Nc3", "Nf6");
     checkException(board, "Nge2", SanValidationProblem.OVERSPECIFIED_RNBQ_FILE_ONLY_ONE_LEGAL_MOVE);
   }
 
@@ -139,65 +139,65 @@ class TestSanValidateAgainstLegalMoves {
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("a4", "a5", "h4", "h5", "Ra3", "Ra6", "Rhh3", "Rhh6", "Rad3", "Rac6", "Rd4", "Rc5", "Rhd3",
+      board.movesStrict("a4", "a5", "h4", "h5", "Ra3", "Ra6", "Rhh3", "Rhh6", "Rad3", "Rac6", "Rd4", "Rc5", "Rhd3",
           "Rhc6", "Rd5", "Rc4");
       // two white rooks
 
       checkException(board, "Rdd4", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("R5d4");
+      board.moveStrict("R5d4");
       // two black rooks
 
       checkException(board, "Rcc5", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("R4c5");
+      board.moveStrict("R4c5");
 
-      board.performMoves("Nf3", "Na6", "Nc3", "Rb6", "Ne4", "Nf6", "Ng3", "Nd5", "Rc4", "c6", "Nf5", "Ndc7", "N5d4",
+      board.movesStrict("Nf3", "Na6", "Nc3", "Rb6", "Ne4", "Nf6", "Ng3", "Nd5", "Rc4", "c6", "Nf5", "Ndc7", "N5d4",
           "Na8", "Nf5", "N8c7");
       // two white knights
 
       checkException(board, "Nfd4", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("N5d4");
+      board.moveStrict("N5d4");
       // two black knights
-      board.performMoves("Na8", "Nf5");
+      board.movesStrict("Na8", "Nf5");
 
       checkException(board, "Nac7", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("N8c7");
+      board.moveStrict("N8c7");
 
-      board.performMoves("g4", "Rb4", "gxh5", "Rxa4", "Bg2", "g6", "hxg6", "Rb4", "g7", "a4", "g8=B", "a3", "Bh7", "a2",
+      board.movesStrict("g4", "Rb4", "gxh5", "Rxa4", "Bg2", "g6", "hxg6", "Rb4", "g7", "a4", "g8=B", "a3", "Bh7", "a2",
           "Ne3", "a1=B", "Bf5", "Bxb2", "Bg4", "Bf6");
       // two white bishops
 
       checkException(board, "Bgh3", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("B4h3");
+      board.moveStrict("B4h3");
       // two black bishops
 
       checkException(board, "Bfg7", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("B6g7");
+      board.moveStrict("B6g7");
 
-      board.performMoves("h5", "b5", "h6", "Ra4", "h7", "b4", "h8=Q", "b3", "Rdd4", "bxc2", "Qh7", "Bb7", "Rb4", "Qb8",
+      board.movesStrict("h5", "b5", "h6", "Ra4", "h7", "b4", "h8=Q", "b3", "Rdd4", "bxc2", "Qh7", "Bb7", "Rb4", "Qb8",
           "Rb1", "cxb1=Q", "Qd3", "Qb6");
       // two white queens
 
       checkException(board, "Qdc2", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("Q3c2");
+      board.moveStrict("Q3c2");
       // two black queens
-      board.performMoves("Ne6", "Qd3");
+      board.movesStrict("Ne6", "Qd3");
 
       checkException(board, "Qbc7", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("Q6c7");
+      board.moveStrict("Q6c7");
     }
 
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("e4", "e5", "Bc4", "Bc5", "Nf3", "Nf6", "O-O", "O-O", "Nxe5", "Nxe4", "Qg4", "Qg5", "Na3",
+      board.movesStrict("e4", "e5", "Bc4", "Bc5", "Nf3", "Nf6", "O-O", "O-O", "Nxe5", "Nxe4", "Qg4", "Qg5", "Na3",
           "Na6", "d4", "d5", "Be3", "Be6", "Bb5", "Bb4", "c4", "c5", "cxd5", "cxd4", "d6", "d3", "d7", "d2", "d8=R",
           "d1=R", "Rd3", "Rc1", "Rfd1", "Rc6", "Rac1", "Rac8", "R1d2", "Rfd8", "Rdc3", "Rd7", "R1c2", "h5", "h4",
           "hxg4", "hxg5", "g6", "g3", "f6", "f3", "gxf3", "gxf6", "f2+", "Kh2", "f1=R", "f7+", "Kh7", "f8=R", "Rff7",
@@ -207,12 +207,12 @@ class TestSanValidateAgainstLegalMoves {
 
       checkException(board, "Rdd2", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("R1d2");
+      board.moveStrict("R1d2");
       // three black rooks
 
       checkException(board, "Rcc7", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_RANK_REQUIRED);
 
-      board.performMove("R8c7");
+      board.moveStrict("R8c7");
     }
 
   }
@@ -223,7 +223,7 @@ class TestSanValidateAgainstLegalMoves {
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=N", "gxh1=N", "Nc3", "Nf6", "Nf3",
+      board.movesStrict("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=N", "gxh1=N", "Nc3", "Nf6", "Nf3",
           "Nc6", "Nb6", "Ng3", "Nba4", "Ngh5", "Nc5", "Nf4", "Ng5", "Nb4", "Nge4", "Nbd5", "Ng5", "Nb4");
 
       // three white knights
@@ -231,19 +231,19 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "Nce4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("N3e4");
+      board.moveStrict("N3e4");
       // three black knights
 
       checkException(board, "Nfd5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("N6d5");
+      board.moveStrict("N6d5");
     }
 
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=N", "gxh1=N", "Nc3", "Nf6", "Nf3",
+      board.movesStrict("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=N", "gxh1=N", "Nc3", "Nf6", "Nf3",
           "Nc6", "Nb6", "Ng3", "Nba4", "Ngh5", "Nc5", "Nf4", "Ng5", "Nb4", "Nge4", "Nbd5", "Ng5", "Nb4", "a4", "h5",
           "a5", "h4", "a6", "h3", "Bg2", "hxg2", "Rb1", "g1=N", "Ra1", "Bb7", "axb7", "Ngh3", "b8=N", "Nxf2", "Nc6",
           "N2e4", "Ne5", "Nd6", "Ned3", "Nc8", "Nf2", "Nb6", "Nh1", "Qc8", "Ng3", "Qb8");
@@ -252,19 +252,19 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "Nce4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Nc3e4");
+      board.moveStrict("Nc3e4");
       // four black knights
 
       checkException(board, "Nbd5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Nb6d5");
+      board.moveStrict("Nb6d5");
     }
 
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=B", "gxh1=B", "e4", "d5", "e5", "d4",
+      board.movesStrict("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=B", "gxh1=B", "e4", "d5", "e5", "d4",
           "e6", "d3", "Qc2", "Nh6", "Bh3", "dxc2", "Bg4", "cxb1=B", "Bgf3", "Nf7", "exf7+", "Kd7", "Be2", "Rg8",
           "fxg8=B", "Bg6", "Bgd5", "Bg2", "Bh5", "Bh3", "Bb3", "Be6", "Bad5", "Be4", "Bbd1", "Ba6", "Bde2", "Bed3",
           "Be4", "Bdc4", "Bf5", "Bxa2", "Bef3", "Qe8");
@@ -273,16 +273,16 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "Bfg4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Bf5g4");
-      board.performMoves("Kd8", "Kd1"); // unpin black bishop
+      board.moveStrict("Bf5g4");
+      board.movesStrict("Kd8", "Kd1"); // unpin black bishop
       // three black bishops
 
       checkException(board, "Bac4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Ba6c4");
+      board.moveStrict("Ba6c4");
 
-      board.performMoves("b4", "g5", "Bh3", "g4", "b5", "g3", "b6", "g2", "b7", "Nc6", "Ne2", "Nb4", "Ng3", "Nd5",
+      board.movesStrict("b4", "g5", "Bh3", "g4", "b5", "g3", "b6", "g2", "b7", "Nc6", "Ne2", "Nb4", "Ng3", "Nd5",
           "Nf1", "gxf1=B", "Bfg4", "Nb6", "Bf5", "Na8", "bxa8=B", "Bb5", "Baf3", "Bc6", "Ke1", "Bd3", "Kd1", "Bac4",
           "Ke1", "Bde4");
       // four white bishops
@@ -290,19 +290,19 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "Bfg4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Bf3g4");
+      board.moveStrict("Bf3g4");
       // four black bishops
 
       checkException(board, "Bed5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Be4d5");
+      board.moveStrict("Be4d5");
     }
 
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("f4", "c5", "f5", "c4", "f6", "c3", "fxg7", "cxb2", "gxh8=Q", "bxa1=Q", "c4", "f5", "c5", "f4",
+      board.movesStrict("f4", "c5", "f5", "c4", "f6", "c3", "fxg7", "cxb2", "gxh8=Q", "bxa1=Q", "c4", "f5", "c5", "f4",
           "c6", "f3", "cxb7", "fxg2", "bxa8=Q", "gxh1=Q", "Qb3", "Qf3", "Qab7", "Qe5", "Qf6", "Qeh5", "Qd6", "e6",
           "Q3b4", "Qdf6", "Q7b6", "Q6f5");
       // three white queens
@@ -310,42 +310,42 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "Qbc5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qb6c5");
+      board.moveStrict("Qb6c5");
       // three black queens
 
       checkException(board, "Qfg4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qf5g4");
+      board.moveStrict("Qf5g4");
 
-      board.performMoves("a4", "Qxh2", "Qxa7", "h5", "a5", "h4", "a6", "Qhg3+", "Kd1", "h3", "Qab6", "h2", "a7", "h1=Q",
+      board.movesStrict("a4", "Qxh2", "Qxa7", "h5", "a5", "h4", "a6", "Qhg3+", "Kd1", "h3", "Qab6", "h2", "a7", "h1=Q",
           "a8=Q", "Qgf5", "Qad5", "Qhh5", "Qdd4", "Qgh3");
       // four white queens
 
       checkException(board, "Qbc5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qb4c5");
+      board.moveStrict("Qb4c5");
       // four black queens
 
       checkException(board, "Qfg4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qf3g4");
+      board.moveStrict("Qf3g4");
 
-      board.performMoves("Qcb4", "Qgf3", "d3", "Be7", "Kc2", "Bf8", "Kb2", "Be7", "Ka1", "Qxe2", "Qa7", "Kf8");
+      board.movesStrict("Qcb4", "Qgf3", "d3", "Be7", "Kc2", "Bf8", "Kb2", "Be7", "Ka1", "Qxe2", "Qa7", "Kf8");
       // four white queens
 
       checkException(board, "Qdc5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qd4c5");
+      board.moveStrict("Qd4c5");
       // four black queens
 
       checkException(board, "Qhg4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_FILE_EITHER_RANK_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qh5g4");
+      board.moveStrict("Qh5g4");
     }
   }
 
@@ -368,7 +368,7 @@ class TestSanValidateAgainstLegalMoves {
     checkException(board, "Q1d3", SanValidationProblem.NOT_REACHABLE_RNBQ_RANK_SINGLE);
 
     // black
-    board.performMoves("e4");
+    board.movesStrict("e4");
     // rook
     checkException(board, "R8a5", SanValidationProblem.NOT_REACHABLE_RNBQ_RANK_MULTIPLE);
 
@@ -390,25 +390,25 @@ class TestSanValidateAgainstLegalMoves {
 
     // white
     // rook
-    board.performMoves("a4");
-    board.performMoves("a5");
+    board.movesStrict("a4");
+    board.movesStrict("a5");
     checkException(board, "R1a2", SanValidationProblem.OVERSPECIFIED_RNBQ_RANK_ONLY_ONE_LEGAL_MOVE);
 
     // knight
     checkException(board, "N1c3", SanValidationProblem.OVERSPECIFIED_RNBQ_RANK_ONLY_ONE_LEGAL_MOVE);
 
     // bishop
-    board.performMoves("b3");
-    board.performMoves("b6");
+    board.movesStrict("b3");
+    board.movesStrict("b6");
     checkException(board, "B1b2", SanValidationProblem.OVERSPECIFIED_RNBQ_RANK_ONLY_ONE_LEGAL_MOVE);
 
     // queen
-    board.performMoves("d4");
-    board.performMoves("d5");
+    board.movesStrict("d4");
+    board.movesStrict("d5");
     checkException(board, "Q1d2", SanValidationProblem.OVERSPECIFIED_RNBQ_RANK_ONLY_ONE_LEGAL_MOVE);
 
     // black
-    board.performMoves("e4");
+    board.movesStrict("e4");
     // rook
     checkException(board, "R8a7", SanValidationProblem.OVERSPECIFIED_RNBQ_RANK_ONLY_ONE_LEGAL_MOVE);
 
@@ -429,58 +429,58 @@ class TestSanValidateAgainstLegalMoves {
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("a4", "a5", "h4", "h5", "Ra3", "Ra6", "Rhh3", "Rhh6", "Rab3", "Rad6", "Rhd3", "Rd5", "Rd4",
+      board.movesStrict("a4", "a5", "h4", "h5", "Ra3", "Ra6", "Rhh3", "Rhh6", "Rab3", "Rad6", "Rhd3", "Rd5", "Rd4",
           "Rg6");
       // two white rooks
 
       checkException(board, "R4b4", SanValidationProblem.NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE);
 
-      board.performMove("Rdb4");
+      board.moveStrict("Rdb4");
       // two black rooks
 
       checkException(board, "R5g5", SanValidationProblem.NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE);
 
-      board.performMove("Rdg5");
+      board.moveStrict("Rdg5");
 
-      board.performMoves("Nf3", "Nf6", "Nc3", "Nc6", "Nd4", "Nd5");
+      board.movesStrict("Nf3", "Nf6", "Nc3", "Nc6", "Nd4", "Nd5");
       // two white knights
 
       checkException(board, "N3b5", SanValidationProblem.NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE);
 
-      board.performMove("Ncb5");
+      board.moveStrict("Ncb5");
       // two black knights
 
       checkException(board, "N5xb4", SanValidationProblem.NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE);
 
-      board.performMove("Ndxb4");
+      board.moveStrict("Ndxb4");
 
-      board.performMoves("e4", "f5", "e5", "d6", "exd6", "f4", "dxc7", "f3", "d3", "fxg2", "Bd2", "g1=B", "Bc1", "Nb8",
+      board.movesStrict("e4", "f5", "e5", "d6", "exd6", "f4", "dxc7", "f3", "d3", "fxg2", "Bd2", "g1=B", "Bc1", "Nb8",
           "cxb8=B", "Bxf2+", "Kd2", "e6", "Bf4", "Bxd4", "Ke1", "Rh6", "Bxg5", "g6", "Bxh6", "Bfg7");
 
       // two white bishops
 
       checkException(board, "B6f4", SanValidationProblem.NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE);
 
-      board.performMove("Bhf4");
+      board.moveStrict("Bhf4");
       // two black bishops
 
       checkException(board, "B4e5", SanValidationProblem.NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE);
 
-      board.performMove("Bde5");
+      board.moveStrict("Bde5");
 
-      board.performMoves("c4", "g5", "c5", "g4", "c6", "g3", "cxb7", "g2", "bxc8=Q", "gxf1=Q+", "Kd2", "Kf7", "Qxh5+",
+      board.movesStrict("c4", "g5", "c5", "g4", "c6", "g3", "cxb7", "g2", "bxc8=Q", "gxf1=Q+", "Kd2", "Kf7", "Qxh5+",
           "Kf6", "Qxe5+", "Kg6", "Qd4", "Qf6", "Qdc4", "Qf2+", "Kd1", "Na2", "Na3", "Nb4", "Q4a6", "Q2d4");
 
       // two white queens
 
       checkException(board, "Q6c6", SanValidationProblem.NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE);
 
-      board.performMove("Qac6");
+      board.moveStrict("Qac6");
       // two black queens
 
       checkException(board, "Q4xf4", SanValidationProblem.NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE);
 
-      board.performMove("Qdxf4");
+      board.moveStrict("Qdxf4");
 
     }
   }
@@ -491,7 +491,7 @@ class TestSanValidateAgainstLegalMoves {
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=N", "gxh1=N", "Nc3", "Nf6", "Nf3",
+      board.movesStrict("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=N", "gxh1=N", "Nc3", "Nf6", "Nf3",
           "Nc6", "Nb6", "Ng3", "Nba4", "Ngh5", "Nc5", "Nf4", "Ng5", "Nb4", "Nge4", "Nbd5", "Ng5", "Nb4");
 
       // three white knights
@@ -499,19 +499,19 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "N5e4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Nc5e4");
+      board.moveStrict("Nc5e4");
       // three black knights
 
       checkException(board, "N4d5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Nf4d5");
+      board.moveStrict("Nf4d5");
     }
 
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=N", "gxh1=N", "Nc3", "Nf6", "Nf3",
+      board.movesStrict("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=N", "gxh1=N", "Nc3", "Nf6", "Nf3",
           "Nc6", "Nb6", "Ng3", "Nba4", "Ngh5", "Nc5", "Nf4", "Ng5", "Nb4", "Nge4", "Nbd5", "Ng5", "Nb4", "a4", "h5",
           "a5", "h4", "a6", "h3", "Bg2", "hxg2", "Rb1", "g1=N", "Ra1", "Bb7", "axb7", "Ngh3", "b8=N", "Nxf2", "Nc6",
           "N2e4", "Ne5", "Nd6", "Ned3", "Nc8", "Nf2", "Nb6", "Nh1", "Qc8", "Ng3", "Qb8");
@@ -520,19 +520,19 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "N3e4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Nc3e4");
+      board.moveStrict("Nc3e4");
       // four black knights
 
       checkException(board, "N6d5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Nb6d5");
+      board.moveStrict("Nb6d5");
     }
 
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=B", "gxh1=B", "e4", "d5", "e5", "d4",
+      board.movesStrict("c4", "f5", "c5", "f4", "c6", "f3", "cxb7", "fxg2", "bxa8=B", "gxh1=B", "e4", "d5", "e5", "d4",
           "e6", "d3", "Qc2", "Nh6", "Bh3", "dxc2", "Bg4", "cxb1=B", "Bgf3", "Nf7", "exf7+", "Kd7", "Be2", "Rg8",
           "fxg8=B", "Bg6", "Bgd5", "Bg2", "Bh5", "Bh3", "Bb3", "Be6", "Bad5", "Be4", "Bbd1", "Ba6", "Bde2", "Bed3",
           "Be4", "Bdc4", "Bf5", "Bxa2", "Bef3", "Qe8");
@@ -541,16 +541,16 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "B5g4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Bf5g4");
-      board.performMoves("Kd8", "Kd1"); // unpin black bishop
+      board.moveStrict("Bf5g4");
+      board.movesStrict("Kd8", "Kd1"); // unpin black bishop
       // three black bishops
 
       checkException(board, "B6c4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Ba6c4");
+      board.moveStrict("Ba6c4");
 
-      board.performMoves("b4", "g5", "Bh3", "g4", "b5", "g3", "b6", "g2", "b7", "Nc6", "Ne2", "Nb4", "Ng3", "Nd5",
+      board.movesStrict("b4", "g5", "Bh3", "g4", "b5", "g3", "b6", "g2", "b7", "Nc6", "Ne2", "Nb4", "Ng3", "Nd5",
           "Nf1", "gxf1=B", "Bfg4", "Nb6", "Bf5", "Na8", "bxa8=B", "Bb5", "Baf3", "Bc6", "Ke1", "Bd3", "Kd1", "Bac4",
           "Ke1", "Bde4");
       // four white bishops
@@ -558,19 +558,19 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "B3g4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Bf3g4");
+      board.moveStrict("Bf3g4");
       // four black bishops
 
       checkException(board, "B4d5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Be4d5");
+      board.moveStrict("Be4d5");
     }
 
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("f4", "c5", "f5", "c4", "f6", "c3", "fxg7", "cxb2", "gxh8=Q", "bxa1=Q", "c4", "f5", "c5", "f4",
+      board.movesStrict("f4", "c5", "f5", "c4", "f6", "c3", "fxg7", "cxb2", "gxh8=Q", "bxa1=Q", "c4", "f5", "c5", "f4",
           "c6", "f3", "cxb7", "fxg2", "bxa8=Q", "gxh1=Q", "Qb3", "Qf3", "Qab7", "Qe5", "Qf6", "Qeh5", "Qd6", "e6",
           "Q3b4", "Qdf6", "Q7b6", "Q6f5");
       // three white queens
@@ -578,42 +578,42 @@ class TestSanValidateAgainstLegalMoves {
       checkException(board, "Q6c5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qb6c5");
+      board.moveStrict("Qb6c5");
       // three black queens
 
       checkException(board, "Q5g4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qf5g4");
+      board.moveStrict("Qf5g4");
 
-      board.performMoves("a4", "Qxh2", "Qxa7", "h5", "a5", "h4", "a6", "Qhg3+", "Kd1", "h3", "Qab6", "h2", "a7", "h1=Q",
+      board.movesStrict("a4", "Qxh2", "Qxa7", "h5", "a5", "h4", "a6", "Qhg3+", "Kd1", "h3", "Qab6", "h2", "a7", "h1=Q",
           "a8=Q", "Qgf5", "Qad5", "Qhh5", "Qdd4", "Qgh3");
       // four white queens
 
       checkException(board, "Q4c5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qb4c5");
+      board.moveStrict("Qb4c5");
       // four black queens
 
       checkException(board, "Q3g4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qf3g4");
+      board.moveStrict("Qf3g4");
 
-      board.performMoves("Qcb4", "Qgf3", "d3", "Be7", "Kc2", "Bf8", "Kb2", "Be7", "Ka1", "Qxe2", "Qa7", "Kf8");
+      board.movesStrict("Qcb4", "Qgf3", "d3", "Be7", "Kc2", "Bf8", "Kb2", "Be7", "Ka1", "Qxe2", "Qa7", "Kf8");
       // four white queens
 
       checkException(board, "Q4c5",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qd4c5");
+      board.moveStrict("Qd4c5");
       // four black queens
 
       checkException(board, "Q5g4",
           SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_RANK_EITHER_FILE_OR_SQUARE_REQUIRED);
 
-      board.performMove("Qh5g4");
+      board.moveStrict("Qh5g4");
     }
   }
 
@@ -634,7 +634,7 @@ class TestSanValidateAgainstLegalMoves {
     checkException(board, "Qd1d4", SanValidationProblem.NOT_REACHABLE_RNBQ_SQUARE);
 
     // black
-    board.performMoves("e4");
+    board.movesStrict("e4");
     // rook no square specification allowed
     // knight
     checkException(board, "Ng8d4", SanValidationProblem.MOVEMENT_RNBQ_FROM_SQUARE);
@@ -667,17 +667,17 @@ class TestSanValidateAgainstLegalMoves {
     checkException(board, "Nb1c3", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_ONLY_ONE_LEGAL_MOVE);
 
     // bishop
-    board.performMoves("b3");
-    board.performMoves("b6");
+    board.movesStrict("b3");
+    board.movesStrict("b6");
     checkException(board, "Bc1b2", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_ONLY_ONE_LEGAL_MOVE);
 
     // queen
-    board.performMoves("d4");
-    board.performMoves("d5");
+    board.movesStrict("d4");
+    board.movesStrict("d5");
     checkException(board, "Qd1d2", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_ONLY_ONE_LEGAL_MOVE);
 
     // black
-    board.performMoves("e4");
+    board.movesStrict("e4");
     // rook no square specification allowed
     // knight
     checkException(board, "Nb8c6", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_ONLY_ONE_LEGAL_MOVE);
@@ -705,54 +705,54 @@ class TestSanValidateAgainstLegalMoves {
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("a4", "a5", "h4", "h5", "Ra3", "Ra6", "Rhh3", "Rhh6", "Rab3", "Rad6", "Rhd3", "Rd5", "Rd4",
+      board.movesStrict("a4", "a5", "h4", "h5", "Ra3", "Ra6", "Rhh3", "Rhh6", "Rab3", "Rad6", "Rhd3", "Rd5", "Rd4",
           "Rg6");
       // two white rooks
       // rook no square specification allowed
-      board.performMove("Rdb4");
+      board.moveStrict("Rdb4");
       // two black rooks
       // rook no square specification allowed
-      board.performMove("Rdg5");
+      board.moveStrict("Rdg5");
 
-      board.performMoves("Nf3", "Nf6", "Nc3", "Nc6", "Nd4", "Nd5");
+      board.movesStrict("Nf3", "Nf6", "Nc3", "Nc6", "Nd4", "Nd5");
       // two white knights
 
       checkException(board, "Nc3b5", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_RANK_NOT_NECESSARY);
 
-      board.performMove("Ncb5");
+      board.moveStrict("Ncb5");
       // two black knights
 
       checkException(board, "Nd5xb4", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_RANK_NOT_NECESSARY);
 
-      board.performMove("Ndxb4");
+      board.moveStrict("Ndxb4");
 
-      board.performMoves("e4", "f5", "e5", "d6", "exd6", "f4", "dxc7", "f3", "d3", "fxg2", "Bd2", "g1=B", "Bc1", "Nb8",
+      board.movesStrict("e4", "f5", "e5", "d6", "exd6", "f4", "dxc7", "f3", "d3", "fxg2", "Bd2", "g1=B", "Bc1", "Nb8",
           "cxb8=B", "Bxf2+", "Kd2", "e6", "Bf4", "Bxd4", "Ke1", "Rh6", "Bxg5", "g6", "Bxh6", "Bfg7");
 
       // two white bishops
 
       checkException(board, "Bh6f4", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_RANK_NOT_NECESSARY);
 
-      board.performMove("Bhf4");
+      board.moveStrict("Bhf4");
       // two black bishops
 
       checkException(board, "Bd4e5", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_RANK_NOT_NECESSARY);
 
-      board.performMove("Bde5");
+      board.moveStrict("Bde5");
 
-      board.performMoves("c4", "g5", "c5", "g4", "c6", "g3", "cxb7", "g2", "bxc8=Q", "gxf1=Q+", "Kd2", "Kf7", "Qxh5+",
+      board.movesStrict("c4", "g5", "c5", "g4", "c6", "g3", "cxb7", "g2", "bxc8=Q", "gxf1=Q+", "Kd2", "Kf7", "Qxh5+",
           "Kf6", "Qxe5+", "Kg6", "Qd4", "Qf6", "Qdc4", "Qf2+", "Kd1", "Na2", "Na3", "Nb4", "Q4a6", "Q2d4");
 
       // two white queens
 
       checkException(board, "Qa6c6", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_RANK_NOT_NECESSARY);
 
-      board.performMove("Qac6");
+      board.moveStrict("Qac6");
       // two black queens
 
       checkException(board, "Qd4xf4", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_RANK_NOT_NECESSARY);
 
-      board.performMove("Qdxf4");
+      board.moveStrict("Qdxf4");
 
     }
   }
@@ -772,62 +772,62 @@ class TestSanValidateAgainstLegalMoves {
     {
       final ChessBoard board = new Board();
 
-      board.performMoves("a4", "a5", "h4", "h5", "Ra3", "Ra6", "Rhh3", "Rhh6", "Rad3", "Rac6", "Rd4", "Rc5", "Rhd3",
+      board.movesStrict("a4", "a5", "h4", "h5", "Ra3", "Ra6", "Rhh3", "Rhh6", "Rad3", "Rac6", "Rd4", "Rc5", "Rhd3",
           "Rhc6", "Rd5", "Rc4");
       // two white rooks
       // rook no square specification allowed
-      board.performMove("R5d4");
+      board.moveStrict("R5d4");
       // two black rooks
       // rook no square specification allowed
-      board.performMove("R4c5");
+      board.moveStrict("R4c5");
 
-      board.performMoves("Nf3", "Na6", "Nc3", "Rb6", "Ne4", "Nf6", "Ng3", "Nd5", "Rc4", "c6", "Nf5", "Ndc7", "N5d4",
+      board.movesStrict("Nf3", "Na6", "Nc3", "Rb6", "Ne4", "Nf6", "Ng3", "Nd5", "Rc4", "c6", "Nf5", "Ndc7", "N5d4",
           "Na8", "Nf5", "N8c7");
       // two white knights
 
       checkException(board, "Nf5d4", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_FILE_NOT_NECESSARY);
 
-      board.performMove("N5d4");
+      board.moveStrict("N5d4");
       // two black knights
-      board.performMoves("Na8", "Nf5");
+      board.movesStrict("Na8", "Nf5");
 
       checkException(board, "Na8c7", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_FILE_NOT_NECESSARY);
 
-      board.performMove("N8c7");
+      board.moveStrict("N8c7");
 
-      board.performMoves("g4", "Rb4", "gxh5", "Rxa4", "Bg2", "g6", "hxg6", "Rb4", "g7", "a4", "g8=B", "a3", "Bh7", "a2",
+      board.movesStrict("g4", "Rb4", "gxh5", "Rxa4", "Bg2", "g6", "hxg6", "Rb4", "g7", "a4", "g8=B", "a3", "Bh7", "a2",
           "Ne3", "a1=B", "Bf5", "Bxb2", "Bg4", "Bf6");
       // two white bishops
 
       checkException(board, "Bg4h3", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_FILE_NOT_NECESSARY);
 
-      board.performMove("B4h3");
+      board.moveStrict("B4h3");
       // two black bishops
 
       checkException(board, "Bf6g7", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_FILE_NOT_NECESSARY);
 
-      board.performMove("B6g7");
+      board.moveStrict("B6g7");
 
-      board.performMoves("h5", "b5", "h6", "Ra4", "h7", "b4", "h8=Q", "b3", "Rdd4", "bxc2", "Qh7", "Bb7", "Rb4", "Qb8",
+      board.movesStrict("h5", "b5", "h6", "Ra4", "h7", "b4", "h8=Q", "b3", "Rdd4", "bxc2", "Qh7", "Bb7", "Rb4", "Qb8",
           "Rb1", "cxb1=Q", "Qd3", "Qb6");
       // two white queens
 
       checkException(board, "Qd3c2", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_FILE_NOT_NECESSARY);
 
-      board.performMove("Q3c2");
+      board.moveStrict("Q3c2");
       // two black queens
-      board.performMoves("Ne6", "Qd3");
+      board.movesStrict("Ne6", "Qd3");
 
       checkException(board, "Qb6c7", SanValidationProblem.OVERSPECIFIED_RNBQ_SQUARE_FILE_NOT_NECESSARY);
 
-      board.performMove("Q6c7");
+      board.moveStrict("Q6c7");
     }
   }
 
   private static void checkException(ChessBoard board, String san, SanValidationProblem expectedValidation) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/TestSanValidateAgainstLegalMovesCastling.java
+++ b/src/test/java/com/dlb/chess/test/san/TestSanValidateAgainstLegalMovesCastling.java
@@ -11,7 +11,7 @@ import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.enums.CastlingCheck;
 import com.dlb.chess.san.exceptions.SanValidationException;
 import com.dlb.chess.san.validate.CastlingCheckMapper;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateAgainstLegalMovesCastling {
 
@@ -21,7 +21,7 @@ class TestSanValidateAgainstLegalMovesCastling {
   @Test
   void testNoRightKingMovedWhite() {
     final ChessBoard board = new Board();
-    board.performMoves("e4", "e5", "Ke2", "d6", "Ke1", "d5");
+    board.movesStrict("e4", "e5", "Ke2", "d6", "Ke1", "d5");
     checkCastlingException("O-O", board, CastlingCheck.FINAL_NO_RIGHT,
         CastlingRightLoss.KING_MOVED);
     checkCastlingException("O-O-O", board, CastlingCheck.FINAL_NO_RIGHT,
@@ -32,7 +32,7 @@ class TestSanValidateAgainstLegalMovesCastling {
   @Test
   void testNoRightKingMovedBlack() {
     final ChessBoard board = new Board();
-    board.performMoves("e4", "e5", "d4", "Ke7", "d5", "Ke8", "Nf3");
+    board.movesStrict("e4", "e5", "d4", "Ke7", "d5", "Ke8", "Nf3");
     checkCastlingException("O-O", board, CastlingCheck.FINAL_NO_RIGHT,
         CastlingRightLoss.KING_MOVED);
   }
@@ -43,7 +43,7 @@ class TestSanValidateAgainstLegalMovesCastling {
   @Test
   void testNoRightKingSideRookMoved() {
     final ChessBoard board = new Board();
-    board.performMoves("h4", "e5", "Rh3", "d6", "Rh1", "d5");
+    board.movesStrict("h4", "e5", "Rh3", "d6", "Rh1", "d5");
     checkCastlingException("O-O", board, CastlingCheck.FINAL_NO_RIGHT,
         CastlingRightLoss.ROOK_MOVED);
   }
@@ -52,8 +52,8 @@ class TestSanValidateAgainstLegalMovesCastling {
   @Test
   void testNoRightQueenSideRookMoved() {
     final ChessBoard board = new Board();
-    board.performMoves("a4", "e5", "Ra3", "d6", "Ra1", "d5");
-    board.performMoves("b3", "Nc6", "Bb2", "Be7", "Nc3", "Nf6", "Qc1", "a6");
+    board.movesStrict("a4", "e5", "Ra3", "d6", "Ra1", "d5");
+    board.movesStrict("b3", "Nc6", "Bb2", "Be7", "Nc3", "Nf6", "Qc1", "a6");
     checkCastlingException("O-O-O", board, CastlingCheck.FINAL_NO_RIGHT,
         CastlingRightLoss.ROOK_MOVED);
   }
@@ -77,7 +77,7 @@ class TestSanValidateAgainstLegalMovesCastling {
   void testSquaresNotEmptyWhite() {
     // Initial position, white tries to castle
     final ChessBoard board = new Board();
-    board.performMoves("e4", "e5");
+    board.movesStrict("e4", "e5");
     // King-side: f1 and g1 occupied
     checkCastlingException("O-O", board, CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY,
         CastlingRightLoss.NOT_LOST);
@@ -90,7 +90,7 @@ class TestSanValidateAgainstLegalMovesCastling {
   @Test
   void testSquaresNotEmptyBlack() {
     final ChessBoard board = new Board();
-    board.performMoves("e4");
+    board.movesStrict("e4");
     checkCastlingException("O-O", board, CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY,
         CastlingRightLoss.NOT_LOST);
     checkCastlingException("O-O-O", board, CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY,
@@ -153,7 +153,7 @@ class TestSanValidateAgainstLegalMovesCastling {
       CastlingRightLoss expectedLoss) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/TestSanValidateBlank.java
+++ b/src/test/java/com/dlb/chess/test/san/TestSanValidateBlank.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateBlank {
 
@@ -22,12 +22,12 @@ class TestSanValidateBlank {
     checkException("", board);
     checkException(" ", board);
 
-    board.performMove("e4");
+    board.moveStrict("e4");
 
     checkException("", board);
     checkException(" ", board);
 
-    board.performMove("e5");
+    board.moveStrict("e5");
 
     checkException("", board);
     checkException(" ", board);
@@ -37,7 +37,7 @@ class TestSanValidateBlank {
   private static void checkException(String san, ChessBoard board) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/TestSanValidatePieceExists.java
+++ b/src/test/java/com/dlb/chess/test/san/TestSanValidatePieceExists.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidatePieceExists {
 
@@ -177,7 +177,7 @@ class TestSanValidatePieceExists {
   private static void checkException(String san, ChessBoard board, SanValidationProblem svp) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/TestSanValidateSanTerminalMarker.java
+++ b/src/test/java/com/dlb/chess/test/san/TestSanValidateSanTerminalMarker.java
@@ -20,11 +20,11 @@ class TestSanValidateSanTerminalMarker {
     checkException("e4#", SanValidationProblem.CHECKMATE_SYMBOL_BUT_NO_CHECK, board);
     checkException("e4+", SanValidationProblem.CHECK_SYMBOL_BUT_NO_CHECK, board);
 
-    board.performMoves("e4", "e5", "Bc4", "Bc5");
+    board.movesStrict("e4", "e5", "Bc4", "Bc5");
     checkException("Bxf7#", SanValidationProblem.CHECKMATE_SYMBOL_BUT_CHECK_ONLY, board);
     checkException("Bxf7", SanValidationProblem.NO_SYMBOL_BUT_CHECK, board);
 
-    board.performMoves("a3", "Nc6", "Qf3", "d6");
+    board.movesStrict("a3", "Nc6", "Qf3", "d6");
     checkException("Qxf7+", SanValidationProblem.CHECK_SYMBOL_BUT_CHECKMATE, board);
     checkException("Qxf7", SanValidationProblem.NO_SYMBOL_BUT_CHECKMATE, board);
   }
@@ -34,16 +34,16 @@ class TestSanValidateSanTerminalMarker {
   void testBlack() {
     final ChessBoard board = new Board();
 
-    board.performMove("e4");
+    board.moveStrict("e4");
 
     checkException("e5#", SanValidationProblem.CHECKMATE_SYMBOL_BUT_NO_CHECK, board);
     checkException("e5+", SanValidationProblem.CHECK_SYMBOL_BUT_NO_CHECK, board);
 
-    board.performMoves("e5", "Bc4", "Bc5", "Nc3");
+    board.movesStrict("e5", "Bc4", "Bc5", "Nc3");
     checkException("Bxf2#", SanValidationProblem.CHECKMATE_SYMBOL_BUT_CHECK_ONLY, board);
     checkException("Bxf2", SanValidationProblem.NO_SYMBOL_BUT_CHECK, board);
 
-    board.performMoves("Qf6", "d3");
+    board.movesStrict("Qf6", "d3");
     checkException("Qxf2+", SanValidationProblem.CHECK_SYMBOL_BUT_CHECKMATE, board);
     checkException("Qxf2", SanValidationProblem.NO_SYMBOL_BUT_CHECKMATE, board);
   }
@@ -51,7 +51,7 @@ class TestSanValidateSanTerminalMarker {
   private static void checkException(String san, SanValidationProblem problem, ChessBoard board) {
     boolean isException;
     try {
-      board.performMove(san);
+      board.moveStrict(san);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/TestSanValidationGameEnded.java
+++ b/src/test/java/com/dlb/chess/test/san/TestSanValidationGameEnded.java
@@ -11,11 +11,11 @@ import com.dlb.chess.common.enums.GameStatus;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 /**
  * Surface-level tests for the strict-pipeline game-end pre-check in
- * {@link SanValidation#validateSan}: one scenario per FIDE-automatic termination
+ * {@link StrictSanParser#parseText}: one scenario per FIDE-automatic termination
  * ({@link GameStatus#CHECKMATE}, {@link GameStatus#STALEMATE},
  * {@link GameStatus#INSUFFICIENT_MATERIAL_BOTH}, {@link GameStatus#FIVE_FOLD_REPETITION_RULE},
  * {@link GameStatus#SEVENTY_FIVE_MOVE_RULE}). Each verifies that any SAN attempted on a
@@ -61,7 +61,7 @@ class TestSanValidationGameEnded {
   @Test
   void testGameEndedByFivefoldRepetition() {
     final ChessBoard board = new Board();
-    board.performMoves("Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8", "Nf3",
+    board.movesStrict("Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8", "Nf3",
         "Nf6", "Ng1", "Ng8");
     check("e4", board, GameStatus.FIVE_FOLD_REPETITION_RULE);
   }
@@ -71,7 +71,7 @@ class TestSanValidationGameEnded {
   private static void check(String san, ChessBoard board, GameStatus expectedGameStatus) {
     var isException = false;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
     } catch (final SanValidationException e) {
       isException = true;
       assertEquals(SanValidationProblem.GAME_ALREADY_ENDED, e.getSanValidationProblem());

--- a/src/test/java/com/dlb/chess/test/san/TestSanValidationProblemMessage.java
+++ b/src/test/java/com/dlb/chess/test/san/TestSanValidationProblemMessage.java
@@ -15,7 +15,7 @@ import com.dlb.chess.common.NonNullWrapperCommon;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 /**
  * Per-entry coverage for {@link SanValidationProblem}. For each enum constant that can be triggered from a SAN input,
@@ -387,7 +387,7 @@ class TestSanValidationProblemMessage {
   @Test
   void testExistsPawn() {
     final Board board = new Board();
-    board.performMoves("a4", "h6", "a5", "h5", "a6", "h4", "axb7", "h3");
+    board.movesStrict("a4", "h6", "a5", "h5", "a6", "h4", "axb7", "h3");
     checkException("a4", board, SanValidationProblem.EXISTS_PAWN, "There is no pawn on file a.");
   }
 
@@ -395,7 +395,7 @@ class TestSanValidationProblemMessage {
   @Test
   void testExistsRnbq() {
     final Board board = new Board();
-    board.performMoves("b3", "g6", "g3", "Bg7", "Na3", "Bxa1", "Nb1", "b6", "Na3", "Bb7", "Nb1", "Bxh1");
+    board.movesStrict("b3", "g6", "g3", "Bg7", "Na3", "Bxa1", "Nb1", "b6", "Na3", "Bb7", "Nb1", "Bxh1");
     checkException("Ra2", board, SanValidationProblem.EXISTS_RNBQ_NEITHER, "There is no rook on the board.");
     checkException("Nac3", SanValidationProblem.EXISTS_RNBQ_FILE, "There is no knight on file a.");
     checkException("Q3d4", SanValidationProblem.EXISTS_RNBQ_RANK, "There is no queen on rank 3.");
@@ -408,7 +408,7 @@ class TestSanValidationProblemMessage {
     // DESTINATION_PAWN_FORWARD_OWN_PIECE: after Nf3 Nf6, white's f-pawn tries to advance to f3 blocked by own knight
     {
       final Board board = new Board();
-      board.performMoves("Nf3", "Nf6");
+      board.movesStrict("Nf3", "Nf6");
       checkException("f3", board, SanValidationProblem.DESTINATION_PAWN_FORWARD_OWN_PIECE,
           "The pawn cannot move forward to square f3 because it is occupied by an own piece.");
     }
@@ -423,7 +423,7 @@ class TestSanValidationProblemMessage {
     // DESTINATION_PAWN_FORWARD_OPPONENT_PIECE_NOT_KING: after d4 d5, white's d-pawn tries d5 blocked by black pawn
     {
       final Board board = new Board();
-      board.performMoves("d4", "d5");
+      board.movesStrict("d4", "d5");
       checkException("d5", board, SanValidationProblem.DESTINATION_PAWN_FORWARD_OPPONENT_PIECE_NOT_KING,
           "The pawn cannot move forward to square d5 because it is occupied by an opponent piece; pawns cannot capture by moving forward.");
     }
@@ -431,7 +431,7 @@ class TestSanValidationProblemMessage {
     // DESTINATION_PAWN_CAPTURE_OWN_PIECE: after Nc3 a6, white's b-pawn tries bxc3 onto own knight
     {
       final Board board = new Board();
-      board.performMoves("Nc3", "a6");
+      board.movesStrict("Nc3", "a6");
       checkException("bxc3", board, SanValidationProblem.DESTINATION_PAWN_CAPTURE_OWN_PIECE,
           "The pawn cannot capture on square c3 because it is occupied by an own piece.");
     }
@@ -478,7 +478,7 @@ class TestSanValidationProblemMessage {
 
     {
       final Board board = new Board();
-      board.performMoves("Nc3", "e6", "Nb5", "e5");
+      board.movesStrict("Nc3", "e6", "Nb5", "e5");
 
       checkException("Na7", board, SanValidationProblem.DESTINATION_RNBQK_OPPONENT_NON_KING_NO_CAPTURE_SYMBOL,
           "The move captures an opponent piece on square a7 but has not capture symbol.");
@@ -495,7 +495,7 @@ class TestSanValidationProblemMessage {
     // KING_CASTLING_FINAL_NO_RIGHT_KING_MOVED: white king moved to e2 and back; O-O fails.
     {
       final Board board = new Board();
-      board.performMoves("e4", "e5", "Ke2", "d6", "Ke1", "d5");
+      board.movesStrict("e4", "e5", "Ke2", "d6", "Ke1", "d5");
       checkException("O-O", board, SanValidationProblem.KING_CASTLING_FINAL_NO_RIGHT_KING_MOVED,
           "King-side castling is not possible anymore because the king has moved.");
     }
@@ -503,7 +503,7 @@ class TestSanValidationProblemMessage {
     // KING_CASTLING_FINAL_NO_RIGHT_ROOK_MOVED: white king-side rook moved to h3 and back; O-O fails.
     {
       final Board board = new Board();
-      board.performMoves("h4", "e5", "Rh3", "d6", "Rh1", "d5");
+      board.movesStrict("h4", "e5", "Rh3", "d6", "Rh1", "d5");
       checkException("O-O", board, SanValidationProblem.KING_CASTLING_FINAL_NO_RIGHT_ROOK_MOVED,
           "King-side castling is not possible anymore because the king-side rook has moved.");
     }
@@ -512,7 +512,7 @@ class TestSanValidationProblemMessage {
     // Bxg2-Bxh1. White then attempts O-O — king-side rook has been captured.
     {
       final Board board = new Board();
-      board.performMoves("a3", "b6", "a4", "Bb7", "a5", "Bxg2", "a6", "Bxh1");
+      board.movesStrict("a3", "b6", "a4", "Bb7", "a5", "Bxg2", "a6", "Bxh1");
       checkException("O-O", board, SanValidationProblem.KING_CASTLING_FINAL_NO_RIGHT_ROOK_CAPTURED,
           "King-side castling is not possible anymore because the king-side rook has been captured.");
     }
@@ -521,7 +521,7 @@ class TestSanValidationProblemMessage {
     // tries O-O-O — all castling rights are lost via having already castled.
     {
       final Board board = new Board();
-      board.performMoves("e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "O-O", "Nf6");
+      board.movesStrict("e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "O-O", "Nf6");
       checkException("O-O-O", board, SanValidationProblem.KING_CASTLING_FINAL_NO_RIGHT_CASTLED,
           "Queen-side castling is not possible anymore because the king has already castled.");
     }
@@ -987,7 +987,7 @@ class TestSanValidationProblemMessage {
       String expectedMessage) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateCapturingNoPiece.java
+++ b/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateCapturingNoPiece.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateCapturingNoPiece {
 
@@ -23,25 +23,25 @@ class TestSanValidateCapturingNoPiece {
     checkExceptionPawn("axb3", board);
 
     // rook
-    board.performMoves("a3");
-    board.performMoves("a6");
+    board.movesStrict("a3");
+    board.movesStrict("a6");
 
     // knight
     checkExceptionRnbqk("Nxc3", board);
 
     // bishop
-    board.performMoves("b3");
-    board.performMoves("b6");
+    board.movesStrict("b3");
+    board.movesStrict("b6");
     checkExceptionRnbqk("Bxb2", board);
 
     // queen
-    board.performMoves("Bb2");
-    board.performMoves("Bb7");
+    board.movesStrict("Bb2");
+    board.movesStrict("Bb7");
     checkExceptionRnbqk("Qxc1", board);
 
     // king
-    board.performMoves("Qc1");
-    board.performMoves("Qc8");
+    board.movesStrict("Qc1");
+    board.movesStrict("Qc8");
     checkExceptionRnbqk("Kxd1", board);
   }
 
@@ -52,31 +52,31 @@ class TestSanValidateCapturingNoPiece {
     final ChessBoard board = new Board();
 
     // pawn
-    board.performMoves("a3");
+    board.movesStrict("a3");
     checkExceptionPawn("axb6", board);
 
     // rook
 
-    board.performMoves("a6");
-    board.performMoves("a4");
+    board.movesStrict("a6");
+    board.movesStrict("a4");
     checkExceptionRnbqk("Rxa7", board);
 
     // knight
     checkExceptionRnbqk("Nxc6", board);
 
     // bishop
-    board.performMoves("b6");
-    board.performMoves("b3");
+    board.movesStrict("b6");
+    board.movesStrict("b3");
     checkExceptionRnbqk("Bxb7", board);
 
     // queen
-    board.performMoves("Bb7");
-    board.performMoves("Bb2");
+    board.movesStrict("Bb7");
+    board.movesStrict("Bb2");
     checkExceptionRnbqk("Qxc8", board);
 
     // king
-    board.performMoves("Qc8");
-    board.performMoves("Qc1");
+    board.movesStrict("Qc8");
+    board.movesStrict("Qc1");
     checkExceptionRnbqk("Kxd8", board);
   }
 
@@ -91,7 +91,7 @@ class TestSanValidateCapturingNoPiece {
   private static void checkException(String san, ChessBoard board, SanValidationProblem expected) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateCapturingOpponentKing.java
+++ b/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateCapturingOpponentKing.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateCapturingOpponentKing {
 
@@ -62,7 +62,7 @@ class TestSanValidateCapturingOpponentKing {
   private static void checkException(String san, ChessBoard board) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateMovingOntoOwnPiece.java
+++ b/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateMovingOntoOwnPiece.java
@@ -14,7 +14,7 @@ class TestSanValidateMovingOntoOwnPiece extends AbstractTestSanValidate {
     final ChessBoard board = new Board("8/3k4/3r4/R7/4K3/8/8/R7 b - - 0 1");
 
     checkExceptionRnbqkMovingOntoOwnPiece("Rd6", board);
-    board.performMoves("Rc6");
+    board.movesStrict("Rc6");
     // rook
     checkExceptionRnbqkMovingOntoOwnPiece("Ra1", board);
   }
@@ -40,8 +40,8 @@ class TestSanValidateMovingOntoOwnPiece extends AbstractTestSanValidate {
     // king
     checkExceptionRnbqkCapturingOwnPiece("Kxf1", board);
 
-    board.performMoves("Nc3");
-    board.performMoves("a6");
+    board.movesStrict("Nc3");
+    board.movesStrict("a6");
 
     // pawn
     checkExceptionPawnCaptureOwnPiece("bxc3", board);
@@ -52,7 +52,7 @@ class TestSanValidateMovingOntoOwnPiece extends AbstractTestSanValidate {
   void testBlack() {
 
     final ChessBoard board = new Board();
-    board.performMoves("e4");
+    board.movesStrict("e4");
 
     // rook
     checkExceptionRnbqkCapturingOwnPiece("Rxa7", board);
@@ -69,8 +69,8 @@ class TestSanValidateMovingOntoOwnPiece extends AbstractTestSanValidate {
     // king
     checkExceptionRnbqkCapturingOwnPiece("Kxf7", board);
 
-    board.performMoves("Nc6");
-    board.performMoves("d4");
+    board.movesStrict("Nc6");
+    board.movesStrict("d4");
 
     // pawn
     checkExceptionPawnCaptureOwnPiece("bxc6", board);

--- a/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateNonCapturingMovingOntoOpponentPiece.java
+++ b/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateNonCapturingMovingOntoOpponentPiece.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateNonCapturingMovingOntoOpponentPiece {
 
@@ -21,52 +21,52 @@ class TestSanValidateNonCapturingMovingOntoOpponentPiece {
     {
       final ChessBoard board = new Board();
 
-      board.performMove("a4");
-      board.performMove("d5");
-      board.performMove("Ra3");
-      board.performMove("Bh3");
+      board.moveStrict("a4");
+      board.moveStrict("d5");
+      board.moveStrict("Ra3");
+      board.moveStrict("Bh3");
       checkException("Rh3", board);
     }
     // knight
     {
       final ChessBoard board = new Board();
 
-      board.performMove("Nc3");
-      board.performMove("Nf6");
-      board.performMove("Ne4");
-      board.performMove("a6");
+      board.moveStrict("Nc3");
+      board.moveStrict("Nf6");
+      board.moveStrict("Ne4");
+      board.moveStrict("a6");
       checkException("Nf6", board);
     }
     // bishop
     {
       final ChessBoard board = new Board();
 
-      board.performMove("e4");
-      board.performMove("e5");
-      board.performMove("Bb5");
-      board.performMove("Nc6");
+      board.moveStrict("e4");
+      board.moveStrict("e5");
+      board.moveStrict("Bb5");
+      board.moveStrict("Nc6");
       checkException("Bc6", board);
     }
     // queen
     {
       final ChessBoard board = new Board();
 
-      board.performMove("e4");
-      board.performMove("e5");
-      board.performMove("Qf3");
-      board.performMove("d5");
+      board.moveStrict("e4");
+      board.moveStrict("e5");
+      board.moveStrict("Qf3");
+      board.moveStrict("d5");
       checkException("Qf7", board);
     }
     // king
     {
       final ChessBoard board = new Board();
 
-      board.performMove("e4");
-      board.performMove("e5");
-      board.performMove("d3");
-      board.performMove("Bc5");
-      board.performMove("f4");
-      board.performMove("Bf2+");
+      board.moveStrict("e4");
+      board.moveStrict("e5");
+      board.moveStrict("d3");
+      board.moveStrict("Bc5");
+      board.moveStrict("f4");
+      board.moveStrict("Bf2+");
       checkException("Kf2", board);
     }
     // pawn diagonal move must contain capture symbol by format specification
@@ -79,53 +79,53 @@ class TestSanValidateNonCapturingMovingOntoOpponentPiece {
     {
       final ChessBoard board = new Board();
 
-      board.performMove("e4");
-      board.performMove("h5");
-      board.performMove("Ba6");
-      board.performMove("Rh6");
-      board.performMove("a3");
+      board.moveStrict("e4");
+      board.moveStrict("h5");
+      board.moveStrict("Ba6");
+      board.moveStrict("Rh6");
+      board.moveStrict("a3");
       checkException("Ra6", board);
     }
     // knight
     {
       final ChessBoard board = new Board();
 
-      board.performMove("Nc3");
-      board.performMove("Nf6");
-      board.performMove("Ne4");
+      board.moveStrict("Nc3");
+      board.moveStrict("Nf6");
+      board.moveStrict("Ne4");
       checkException("Ne4", board);
     }
     // bishop
     {
       final ChessBoard board = new Board();
 
-      board.performMove("Nf3");
-      board.performMove("d5");
-      board.performMove("e4");
-      board.performMove("Bg4");
-      board.performMove("d4");
+      board.moveStrict("Nf3");
+      board.moveStrict("d5");
+      board.moveStrict("e4");
+      board.moveStrict("Bg4");
+      board.moveStrict("d4");
       checkException("Bf3", board);
     }
     // queen
     {
       final ChessBoard board = new Board();
 
-      board.performMove("e4");
-      board.performMove("e5");
-      board.performMove("a3");
-      board.performMove("Qf6");
-      board.performMove("d4");
+      board.moveStrict("e4");
+      board.moveStrict("e5");
+      board.moveStrict("a3");
+      board.moveStrict("Qf6");
+      board.moveStrict("d4");
       checkException("Qf2", board);
     }
     // king
     {
       final ChessBoard board = new Board();
 
-      board.performMove("e4");
-      board.performMove("e5");
-      board.performMove("Bc4");
-      board.performMove("d6");
-      board.performMove("Bxf7+");
+      board.moveStrict("e4");
+      board.moveStrict("e5");
+      board.moveStrict("Bc4");
+      board.moveStrict("d6");
+      board.moveStrict("Bxf7+");
       checkException("Kf7", board);
     }
     // pawn diagonal move must contain capture symbol by format specification
@@ -134,7 +134,7 @@ class TestSanValidateNonCapturingMovingOntoOpponentPiece {
   private static void checkException(String san, ChessBoard board) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateNonMovement.java
+++ b/src/test/java/com/dlb/chess/test/san/destinationsquare/TestSanValidateNonMovement.java
@@ -23,7 +23,7 @@ class TestSanValidateNonMovement extends AbstractTestSanValidate {
     checkExceptionNonMovement("Qd1d1", board);
     checkExceptionFormat("Ke1e1", SanValidationProblem.FORMAT_KING_NON_CASTLING_NON_CAPTURE_OVERLENGTH, board);
 
-    board.performMove("e4");
+    board.moveStrict("e4");
 
     checkExceptionNonMovement("Ra8a8", board);
     checkExceptionNonMovement("Nb8b8", board);
@@ -31,51 +31,51 @@ class TestSanValidateNonMovement extends AbstractTestSanValidate {
     checkExceptionNonMovement("Qd8d8", board);
     checkExceptionFormat("Ke8e8", SanValidationProblem.FORMAT_KING_NON_CASTLING_NON_CAPTURE_OVERLENGTH, board);
 
-    board.performMove("e5");
+    board.moveStrict("e5");
 
     // rooks after moved
-    board.performMove("a4");
-    board.performMove("h5");
-    board.performMove("Ra2");
-    board.performMove("Rh7");
+    board.moveStrict("a4");
+    board.moveStrict("h5");
+    board.moveStrict("Ra2");
+    board.moveStrict("Rh7");
     checkExceptionNonMovement("Ra2a2", board);
-    board.performMove("Ra3");
+    board.moveStrict("Ra3");
     checkExceptionNonMovement("Rh7h7", board);
-    board.performMove("Rh6");
+    board.moveStrict("Rh6");
 
     // knights after moved
-    board.performMove("Nc3");
-    board.performMove("Nf6");
+    board.moveStrict("Nc3");
+    board.moveStrict("Nf6");
     checkExceptionNonMovement("Nc3c3", board);
-    board.performMove("Nd5");
+    board.moveStrict("Nd5");
     checkExceptionNonMovement("Nf6f6", board);
-    board.performMove("Nxe4");
+    board.moveStrict("Nxe4");
 
     // bishops after moved
-    board.performMove("Bc4");
-    board.performMove("d6");
+    board.moveStrict("Bc4");
+    board.moveStrict("d6");
     checkExceptionNonMovement("Bc4c4", board);
-    board.performMove("Bf1");
-    board.performMove("Bd7");
-    board.performMove("Bc4");
+    board.moveStrict("Bf1");
+    board.moveStrict("Bd7");
+    board.moveStrict("Bc4");
     checkExceptionNonMovement("Bd7d7", board);
-    board.performMove("Bg4");
+    board.moveStrict("Bg4");
 
     // queens after moved
-    board.performMove("Qxg4");
-    board.performMove("Qd7");
+    board.moveStrict("Qxg4");
+    board.moveStrict("Qd7");
     checkExceptionNonMovement("Qg4g4", board);
-    board.performMove("Qh3");
+    board.moveStrict("Qh3");
     checkExceptionNonMovement("Qd7d7", board);
-    board.performMove("Qc6");
+    board.moveStrict("Qc6");
 
     // kings after moved
-    board.performMove("Kd1");
-    board.performMove("Kd8");
+    board.moveStrict("Kd1");
+    board.moveStrict("Kd8");
     checkExceptionFormat("Kd1d1", SanValidationProblem.FORMAT_KING_NON_CASTLING_NON_CAPTURE_OVERLENGTH, board);
-    board.performMove("Ke2");
+    board.moveStrict("Ke2");
     checkExceptionFormat("Kd8d8", SanValidationProblem.FORMAT_KING_NON_CASTLING_NON_CAPTURE_OVERLENGTH, board);
-    board.performMove("Ke8");
+    board.moveStrict("Ke8");
 
   }
 

--- a/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
+++ b/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
@@ -345,6 +345,36 @@ class TestLenientSanParser implements EnumConstants {
   }
 
   @Test
+  void testLowercaseBishopCaptureNonAdjacentFile() {
+    // Regression: "bxf7" after 1.e4 e5 2.Bc4 Nc6 was treated as b-file pawn capture (illegal — non-adjacent)
+    // and rejected. The b-pawn cannot reach f7 geometrically, so the user must mean a lowercase bishop
+    // capture. Should resolve to canonical "Bxf7+" (the move is also check) with LOWERCASE_PIECE_LETTER and
+    // MISSING_CHECK_SUFFIX.
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("e5");
+    board.performMove("Bc4");
+    board.performMove("Nc6");
+    final LenientSanParserValidationResult result = board.performMoveLenient("bxf7");
+    assertContainsCode(result, LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
+    assertContainsCode(result, LenientSanValidationProblem.MISSING_CHECK_SUFFIX);
+    assertEquals("Bxf7+", canonical(result));
+  }
+
+  @Test
+  void testUppercaseBPawnCapturePromotionMissingEquals() {
+    // Regression: "Bxa8Q" (uppercase b-file pawn capture promotion missing the '=') was rejected because
+    // isUppercaseBPawnOnlyShape didn't cover the length-5 case. Should resolve to canonical "bxa8=Q" with
+    // UPPERCASE_FILE_LETTER and MISSING_PROMOTION_EQUALS. (Bishops don't promote, so uppercase B at the head
+    // of a capture-promotion shape unambiguously means b-file pawn.)
+    final Board board = new Board("r3k3/1P6/8/8/8/8/8/4K3 w - - 0 1");
+    final LenientSanParserValidationResult result = board.performMoveLenient("Bxa8Q");
+    assertContainsCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
+    assertContainsCode(result, LenientSanValidationProblem.MISSING_PROMOTION_EQUALS);
+    assertEquals("bxa8=Q+", canonical(result));
+  }
+
+  @Test
   void testMissingCaptureMarkerPawn() {
     // Regression: pawn captures missing the 'x' (e.g. "ed5" after 1.e4 d5) were rejected, despite the spec
     // documenting MISSING_CAPTURE_MARKER without a piece-only caveat. Should resolve to canonical "exd5".

--- a/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
+++ b/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import com.dlb.chess.board.Board;
+import com.dlb.chess.common.NonNullWrapperCommon;
 import com.dlb.chess.common.constants.EnumConstants;
 import com.dlb.chess.common.ucimove.utility.UciMoveUtility;
 import com.dlb.chess.model.LegalMove;
@@ -26,8 +27,8 @@ class TestLenientSanParser implements EnumConstants {
   // Italian-game opening that exercises pawn pushes, knight/bishop development, and castling.
   // Castling is the only move whose canonical SAN, LAN, and UCI representations all differ — the rest
   // give us pawn vs piece coverage in each notation form.
-  private static final List<String> ITALIAN_OPENING_SAN = List.of("e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "O-O", "Nf6",
-      "d3", "d6");
+  private static final List<String> ITALIAN_OPENING_SAN = NonNullWrapperCommon.listOf("e4", "e5", "Nf3", "Nc6", "Bc4",
+      "Bc5", "O-O", "Nf6", "d3", "d6");
 
   // ---------------------------------------------------------------------------
   // Three full-game tests (canonical SAN / UCI / LAN end-to-end).
@@ -38,8 +39,8 @@ class TestLenientSanParser implements EnumConstants {
     final Board board = new Board();
     for (final String san : ITALIAN_OPENING_SAN) {
       final LenientSanParserValidationResult result = board.moveLenient(san);
-      assertTrue(result.forgivenItems().isEmpty(), "Expected no forgiven items for canonical SAN move: " + san
-          + " (got " + result.forgivenItems() + ")");
+      assertTrue(result.forgivenItems().isEmpty(),
+          "Expected no forgiven items for canonical SAN move: " + san + " (got " + result.forgivenItems() + ")");
     }
   }
 
@@ -76,7 +77,8 @@ class TestLenientSanParser implements EnumConstants {
         sawLongAlgebraic = true;
       }
     }
-    assertTrue(sawLongAlgebraic, "Expected at least one LONG_ALGEBRAIC_NOTATION forgiven item across the LAN-form game");
+    assertTrue(sawLongAlgebraic,
+        "Expected at least one LONG_ALGEBRAIC_NOTATION forgiven item across the LAN-form game");
   }
 
   // ---------------------------------------------------------------------------
@@ -513,14 +515,12 @@ class TestLenientSanParser implements EnumConstants {
       LenientSanValidationProblem expectedCode) {
     assertEquals(1, result.forgivenItems().size(),
         "Expected exactly one forgiven item with code " + expectedCode + " but got " + result.forgivenItems());
-    final ForgivenItem item = result.forgivenItems().get(0);
-    assertEquals(expectedCode, item.code(),
-        "Expected forgiven code " + expectedCode + " but got " + item.code());
+    final ForgivenItem item = NonNullWrapperCommon.get(result.forgivenItems(), 0);
+    assertEquals(expectedCode, item.code(), "Expected forgiven code " + expectedCode + " but got " + item.code());
   }
 
   private static String canonical(LenientSanParserValidationResult result) {
-    assertFalse(result.forgivenItems().isEmpty(),
-        "Cannot extract canonical SAN from a result with no forgiven items");
-    return result.forgivenItems().get(0).canonicalSan();
+    assertFalse(result.forgivenItems().isEmpty(), "Cannot extract canonical SAN from a result with no forgiven items");
+    return NonNullWrapperCommon.get(result.forgivenItems(), 0).canonicalSan();
   }
 }

--- a/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
+++ b/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
@@ -301,6 +301,62 @@ class TestLenientSanParser implements EnumConstants {
   }
 
   // ---------------------------------------------------------------------------
+  // Regression tests — bugs surfaced post-merge.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testBFilePawnWithSpuriousCheckSuffix() {
+    // Regression: lowercase b at position 0 was being case-folded to bishop ("b4+" -> "B4+") even when the
+    // body shape is pawn-compatible. Should resolve to canonical "b4" with SPURIOUS_CHECK_SUFFIX.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("b4+");
+    assertExactlyOneCode(result, LenientSanValidationProblem.SPURIOUS_CHECK_SUFFIX);
+    assertEquals("b4", canonical(result));
+  }
+
+  @Test
+  void testUppercaseFileLetterAtPositionZeroPawn() {
+    // Regression: caseFixUppercaseFileLetters skipped position 0, so "E4" was rejected. Should resolve to
+    // canonical "e4" with UPPERCASE_FILE_LETTER.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("E4");
+    assertExactlyOneCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
+    assertEquals("e4", canonical(result));
+  }
+
+  @Test
+  void testUppercaseFileLetterAtPositionZeroUci() {
+    // Regression: "E2E4" (UCI form with uppercase files) was rejected.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("E2E4");
+    assertContainsCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
+    assertContainsCode(result, LenientSanValidationProblem.UCI_NOTATION);
+    assertEquals("e4", canonical(result));
+  }
+
+  @Test
+  void testUppercaseFileLetterAtPositionZeroLan() {
+    // Regression: "E2-E4" (LAN form with uppercase files) was rejected.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("E2-E4");
+    assertContainsCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
+    assertContainsCode(result, LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION);
+    assertEquals("e4", canonical(result));
+  }
+
+  @Test
+  void testMissingCaptureMarkerPawn() {
+    // Regression: pawn captures missing the 'x' (e.g. "ed5" after 1.e4 d5) were rejected, despite the spec
+    // documenting MISSING_CAPTURE_MARKER without a piece-only caveat. Should resolve to canonical "exd5".
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("d5");
+    final LenientSanParserValidationResult result = board.performMoveLenient("ed5");
+    assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_CAPTURE_MARKER);
+    assertEquals("exd5", canonical(result));
+  }
+
+  // ---------------------------------------------------------------------------
   // Combination tests — multiple codes on one move.
   // ---------------------------------------------------------------------------
 

--- a/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
+++ b/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.dlb.chess.board.Board;
@@ -23,8 +26,8 @@ class TestLenientSanParser implements EnumConstants {
   // Italian-game opening that exercises pawn pushes, knight/bishop development, and castling.
   // Castling is the only move whose canonical SAN, LAN, and UCI representations all differ — the rest
   // give us pawn vs piece coverage in each notation form.
-  private static final String[] ITALIAN_OPENING_SAN = { "e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "O-O", "Nf6", "d3",
-      "d6" };
+  private static final List<String> ITALIAN_OPENING_SAN = List.of("e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "O-O", "Nf6",
+      "d3", "d6");
 
   // ---------------------------------------------------------------------------
   // Three full-game tests (canonical SAN / UCI / LAN end-to-end).
@@ -42,11 +45,10 @@ class TestLenientSanParser implements EnumConstants {
 
   @Test
   void testGameInUciNotation() {
-    final String[] uciMoves = computeUciForms(ITALIAN_OPENING_SAN);
+    final List<String> uciMoves = computeUciForms(ITALIAN_OPENING_SAN);
     final Board board = new Board();
     var sawUciCode = false;
-    for (var i = 0; i < uciMoves.length; i++) {
-      final String uci = uciMoves[i];
+    for (final String uci : uciMoves) {
       final LenientSanParserValidationResult result = board.performMoveLenient(uci);
       if (containsCode(result, LenientSanValidationProblem.UCI_NOTATION)) {
         sawUciCode = true;
@@ -59,18 +61,17 @@ class TestLenientSanParser implements EnumConstants {
   void testGameInLanNotation() {
     // Use the project's getLan() output, then ensure pawn-forward moves get a hyphen so they're
     // unambiguously LAN (not UCI-equivalent).
-    final String[] sanMoves = ITALIAN_OPENING_SAN;
     final Board ref = new Board();
-    final String[] lanMoves = new String[sanMoves.length];
-    for (var i = 0; i < sanMoves.length; i++) {
-      ref.performMove(sanMoves[i]);
-      lanMoves[i] = toUnambiguousLan(ref.getLan());
+    final List<String> lanMoves = new ArrayList<>(ITALIAN_OPENING_SAN.size());
+    for (final String san : ITALIAN_OPENING_SAN) {
+      ref.performMove(san);
+      lanMoves.add(toUnambiguousLan(ref.getLan()));
     }
 
     final Board board = new Board();
     var sawLongAlgebraic = false;
-    for (var i = 0; i < lanMoves.length; i++) {
-      final LenientSanParserValidationResult result = board.performMoveLenient(lanMoves[i]);
+    for (final String lan : lanMoves) {
+      final LenientSanParserValidationResult result = board.performMoveLenient(lan);
       if (containsCode(result, LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION)) {
         sawLongAlgebraic = true;
       }
@@ -379,14 +380,14 @@ class TestLenientSanParser implements EnumConstants {
   // Helpers.
   // ---------------------------------------------------------------------------
 
-  private static String[] computeUciForms(String[] sanMoves) {
+  private static List<String> computeUciForms(List<String> sanMoves) {
     final Board ref = new Board();
-    final String[] uci = new String[sanMoves.length];
-    for (var i = 0; i < sanMoves.length; i++) {
-      ref.performMove(sanMoves[i]);
+    final List<String> uci = new ArrayList<>(sanMoves.size());
+    for (final String san : sanMoves) {
+      ref.performMove(san);
       final LegalMove last = ref.getLastMove();
       final UciMove uciMove = UciMoveUtility.convertMoveSpecificationToUci(last.havingMove(), last.moveSpecification());
-      uci[i] = uciMove.text();
+      uci.add(uciMove.text());
     }
     return uci;
   }

--- a/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
+++ b/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
@@ -37,7 +37,7 @@ class TestLenientSanParser implements EnumConstants {
   void testCanonicalSanGameProducesNoForgivenItems() {
     final Board board = new Board();
     for (final String san : ITALIAN_OPENING_SAN) {
-      final LenientSanParserValidationResult result = board.performMoveLenient(san);
+      final LenientSanParserValidationResult result = board.moveLenient(san);
       assertTrue(result.forgivenItems().isEmpty(), "Expected no forgiven items for canonical SAN move: " + san
           + " (got " + result.forgivenItems() + ")");
     }
@@ -49,7 +49,7 @@ class TestLenientSanParser implements EnumConstants {
     final Board board = new Board();
     var sawUciCode = false;
     for (final String uci : uciMoves) {
-      final LenientSanParserValidationResult result = board.performMoveLenient(uci);
+      final LenientSanParserValidationResult result = board.moveLenient(uci);
       if (containsCode(result, LenientSanValidationProblem.UCI_NOTATION)) {
         sawUciCode = true;
       }
@@ -64,14 +64,14 @@ class TestLenientSanParser implements EnumConstants {
     final Board ref = new Board();
     final List<String> lanMoves = new ArrayList<>(ITALIAN_OPENING_SAN.size());
     for (final String san : ITALIAN_OPENING_SAN) {
-      ref.performMove(san);
+      ref.moveStrict(san);
       lanMoves.add(toUnambiguousLan(ref.getLan()));
     }
 
     final Board board = new Board();
     var sawLongAlgebraic = false;
     for (final String lan : lanMoves) {
-      final LenientSanParserValidationResult result = board.performMoveLenient(lan);
+      final LenientSanParserValidationResult result = board.moveLenient(lan);
       if (containsCode(result, LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION)) {
         sawLongAlgebraic = true;
       }
@@ -87,11 +87,11 @@ class TestLenientSanParser implements EnumConstants {
   void testMissingCheckSuffix() {
     // After 1.e4 e5 2.Bc4 Nc6, white's Bxf7+ is check (not mate).
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("e5");
-    board.performMove("Bc4");
-    board.performMove("Nc6");
-    final LenientSanParserValidationResult result = board.performMoveLenient("Bxf7");
+    board.moveStrict("e4");
+    board.moveStrict("e5");
+    board.moveStrict("Bc4");
+    board.moveStrict("Nc6");
+    final LenientSanParserValidationResult result = board.moveLenient("Bxf7");
     assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_CHECK_SUFFIX);
     assertEquals("Bxf7+", canonical(result));
   }
@@ -100,7 +100,7 @@ class TestLenientSanParser implements EnumConstants {
   void testMissingCheckmateSuffix() {
     // Back-rank mate: white rook to a8 mates black king on g8.
     final Board board = new Board("6k1/5ppp/8/8/8/8/8/R6K w - - 0 1");
-    final LenientSanParserValidationResult result = board.performMoveLenient("Ra8");
+    final LenientSanParserValidationResult result = board.moveLenient("Ra8");
     assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_CHECKMATE_SUFFIX);
     assertEquals("Ra8#", canonical(result));
   }
@@ -109,7 +109,7 @@ class TestLenientSanParser implements EnumConstants {
   void testSpuriousCheckSuffix() {
     // 1.e4+ — pawn push that's not a check.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("e4+");
+    final LenientSanParserValidationResult result = board.moveLenient("e4+");
     assertExactlyOneCode(result, LenientSanValidationProblem.SPURIOUS_CHECK_SUFFIX);
     assertEquals("e4", canonical(result));
   }
@@ -118,7 +118,7 @@ class TestLenientSanParser implements EnumConstants {
   void testSpuriousCheckmateSuffix() {
     // 1.e4# — pawn push that's not mate.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("e4#");
+    final LenientSanParserValidationResult result = board.moveLenient("e4#");
     assertExactlyOneCode(result, LenientSanValidationProblem.SPURIOUS_CHECKMATE_SUFFIX);
     assertEquals("e4", canonical(result));
   }
@@ -127,7 +127,7 @@ class TestLenientSanParser implements EnumConstants {
   void testWrongCheckSuffixForCheckmate() {
     // Back-rank mate written with + instead of #.
     final Board board = new Board("6k1/5ppp/8/8/8/8/8/R6K w - - 0 1");
-    final LenientSanParserValidationResult result = board.performMoveLenient("Ra8+");
+    final LenientSanParserValidationResult result = board.moveLenient("Ra8+");
     assertExactlyOneCode(result, LenientSanValidationProblem.WRONG_CHECK_SUFFIX_FOR_CHECKMATE);
     assertEquals("Ra8#", canonical(result));
   }
@@ -136,11 +136,11 @@ class TestLenientSanParser implements EnumConstants {
   void testWrongCheckmateSuffixForCheck() {
     // Bxf7 in Italian is check, not mate. Written with # instead of +.
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("e5");
-    board.performMove("Bc4");
-    board.performMove("Nc6");
-    final LenientSanParserValidationResult result = board.performMoveLenient("Bxf7#");
+    board.moveStrict("e4");
+    board.moveStrict("e5");
+    board.moveStrict("Bc4");
+    board.moveStrict("Nc6");
+    final LenientSanParserValidationResult result = board.moveLenient("Bxf7#");
     assertExactlyOneCode(result, LenientSanValidationProblem.WRONG_CHECKMATE_SUFFIX_FOR_CHECK);
     assertEquals("Bxf7+", canonical(result));
   }
@@ -149,11 +149,11 @@ class TestLenientSanParser implements EnumConstants {
   void testMissingCaptureMarker() {
     // After 1.e4 e5 2.Nf3 d6 3.Nxe5 — knight capture on e5. Lenient: "Ne5" without x.
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("e5");
-    board.performMove("Nf3");
-    board.performMove("d6");
-    final LenientSanParserValidationResult result = board.performMoveLenient("Ne5");
+    board.moveStrict("e4");
+    board.moveStrict("e5");
+    board.moveStrict("Nf3");
+    board.moveStrict("d6");
+    final LenientSanParserValidationResult result = board.moveLenient("Ne5");
     assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_CAPTURE_MARKER);
     assertEquals("Nxe5", canonical(result));
   }
@@ -162,9 +162,9 @@ class TestLenientSanParser implements EnumConstants {
   void testSpuriousCaptureMarker() {
     // 1.e4 e5 2.Bxc4 — bishop to c4 is not a capture (c4 is empty).
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("e5");
-    final LenientSanParserValidationResult result = board.performMoveLenient("Bxc4");
+    board.moveStrict("e4");
+    board.moveStrict("e5");
+    final LenientSanParserValidationResult result = board.moveLenient("Bxc4");
     assertExactlyOneCode(result, LenientSanValidationProblem.SPURIOUS_CAPTURE_MARKER);
     assertEquals("Bc4", canonical(result));
   }
@@ -173,8 +173,8 @@ class TestLenientSanParser implements EnumConstants {
   void testOverspecifiedFileDisambiguation() {
     // After 1.e4, black plays "Nbc6" — only Nb8 can reach c6, file disambig is unnecessary.
     final Board board = new Board();
-    board.performMove("e4");
-    final LenientSanParserValidationResult result = board.performMoveLenient("Nbc6");
+    board.moveStrict("e4");
+    final LenientSanParserValidationResult result = board.moveLenient("Nbc6");
     assertExactlyOneCode(result, LenientSanValidationProblem.OVERSPECIFIED_FILE_DISAMBIGUATION);
     assertEquals("Nc6", canonical(result));
   }
@@ -183,7 +183,7 @@ class TestLenientSanParser implements EnumConstants {
   void testOverspecifiedRankDisambiguation() {
     // Single white knight on d5; "N5e7" is rank-disambiguated but rank not necessary.
     final Board board = new Board("4k3/8/8/3N4/8/8/P7/4K3 w - - 0 1");
-    final LenientSanParserValidationResult result = board.performMoveLenient("N5e7");
+    final LenientSanParserValidationResult result = board.moveLenient("N5e7");
     assertExactlyOneCode(result, LenientSanValidationProblem.OVERSPECIFIED_RANK_DISAMBIGUATION);
     assertEquals("Ne7", canonical(result));
   }
@@ -195,7 +195,7 @@ class TestLenientSanParser implements EnumConstants {
     // but is non-canonical — strict throws NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE; lenient resolves to
     // "Rda1" by board lookup.
     final Board board = new Board("7k/8/8/8/R7/8/8/3R3K w - - 0 1");
-    final LenientSanParserValidationResult result = board.performMoveLenient("R1a1");
+    final LenientSanParserValidationResult result = board.moveLenient("R1a1");
     assertExactlyOneCode(result, LenientSanValidationProblem.NON_STANDARD_RANK_DISAMBIGUATION);
     assertEquals("Rda1", canonical(result));
   }
@@ -204,7 +204,7 @@ class TestLenientSanParser implements EnumConstants {
   void testOverspecifiedSquareDisambiguation() {
     // Single white knight on d5; "Nd5e7" is square-disambiguated (both file and rank unnecessary).
     final Board board = new Board("4k3/8/8/3N4/8/8/P7/4K3 w - - 0 1");
-    final LenientSanParserValidationResult result = board.performMoveLenient("Nd5e7");
+    final LenientSanParserValidationResult result = board.moveLenient("Nd5e7");
     assertExactlyOneCode(result, LenientSanValidationProblem.OVERSPECIFIED_SQUARE_DISAMBIGUATION);
     assertEquals("Ne7", canonical(result));
   }
@@ -213,7 +213,7 @@ class TestLenientSanParser implements EnumConstants {
   void testLongAlgebraicNotation() {
     // 1.e2-e4 — pawn move with explicit from-square and hyphen.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("e2-e4");
+    final LenientSanParserValidationResult result = board.moveLenient("e2-e4");
     assertContainsCode(result, LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION);
     assertEquals("e4", canonical(result));
   }
@@ -222,7 +222,7 @@ class TestLenientSanParser implements EnumConstants {
   void testUciNotation() {
     // 1.e2e4 — pawn UCI form (no hyphen, no piece letter).
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("e2e4");
+    final LenientSanParserValidationResult result = board.moveLenient("e2e4");
     assertExactlyOneCode(result, LenientSanValidationProblem.UCI_NOTATION);
     assertEquals("e4", canonical(result));
   }
@@ -231,13 +231,13 @@ class TestLenientSanParser implements EnumConstants {
   void testZeroInsteadOfOCastling() {
     // Set up castle-eligible position and play 0-0.
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("e5");
-    board.performMove("Nf3");
-    board.performMove("Nc6");
-    board.performMove("Bc4");
-    board.performMove("Bc5");
-    final LenientSanParserValidationResult result = board.performMoveLenient("0-0");
+    board.moveStrict("e4");
+    board.moveStrict("e5");
+    board.moveStrict("Nf3");
+    board.moveStrict("Nc6");
+    board.moveStrict("Bc4");
+    board.moveStrict("Bc5");
+    final LenientSanParserValidationResult result = board.moveLenient("0-0");
     assertExactlyOneCode(result, LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING);
     assertEquals("O-O", canonical(result));
   }
@@ -246,7 +246,7 @@ class TestLenientSanParser implements EnumConstants {
   void testExplicitPawnLetter() {
     // 1.Pe4 — explicit pawn letter prefix.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("Pe4");
+    final LenientSanParserValidationResult result = board.moveLenient("Pe4");
     assertExactlyOneCode(result, LenientSanValidationProblem.EXPLICIT_PAWN_LETTER);
     assertEquals("e4", canonical(result));
   }
@@ -255,7 +255,7 @@ class TestLenientSanParser implements EnumConstants {
   void testMissingPromotionEquals() {
     // White pawn on a7, plays a8Q (no = symbol).
     final Board board = new Board("8/P7/1k6/8/8/8/8/4K3 w - - 0 1");
-    final LenientSanParserValidationResult result = board.performMoveLenient("a8Q");
+    final LenientSanParserValidationResult result = board.moveLenient("a8Q");
     assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_PROMOTION_EQUALS);
     assertEquals("a8=Q", canonical(result));
   }
@@ -264,7 +264,7 @@ class TestLenientSanParser implements EnumConstants {
   void testLowercasePieceLetter() {
     // 1.nf3 — lowercase knight letter.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("nf3");
+    final LenientSanParserValidationResult result = board.moveLenient("nf3");
     assertExactlyOneCode(result, LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
     assertEquals("Nf3", canonical(result));
   }
@@ -273,7 +273,7 @@ class TestLenientSanParser implements EnumConstants {
   void testUppercaseFileLetter() {
     // 1.NF3 — uppercase file letter.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("NF3");
+    final LenientSanParserValidationResult result = board.moveLenient("NF3");
     assertExactlyOneCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
     assertEquals("Nf3", canonical(result));
   }
@@ -282,11 +282,11 @@ class TestLenientSanParser implements EnumConstants {
   void testUppercaseCaptureMarker() {
     // 1.e4 e5 2.Nf3 d6 3.NXe5 — uppercase X.
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("e5");
-    board.performMove("Nf3");
-    board.performMove("d6");
-    final LenientSanParserValidationResult result = board.performMoveLenient("NXe5");
+    board.moveStrict("e4");
+    board.moveStrict("e5");
+    board.moveStrict("Nf3");
+    board.moveStrict("d6");
+    final LenientSanParserValidationResult result = board.moveLenient("NXe5");
     assertExactlyOneCode(result, LenientSanValidationProblem.UPPERCASE_CAPTURE_MARKER);
     assertEquals("Nxe5", canonical(result));
   }
@@ -295,7 +295,7 @@ class TestLenientSanParser implements EnumConstants {
   void testLowercasePromotionPiece() {
     // White pawn on a7, plays a8=q (lowercase q).
     final Board board = new Board("8/P7/1k6/8/8/8/8/4K3 w - - 0 1");
-    final LenientSanParserValidationResult result = board.performMoveLenient("a8=q");
+    final LenientSanParserValidationResult result = board.moveLenient("a8=q");
     assertExactlyOneCode(result, LenientSanValidationProblem.LOWERCASE_PROMOTION_PIECE);
     assertEquals("a8=Q", canonical(result));
   }
@@ -309,7 +309,7 @@ class TestLenientSanParser implements EnumConstants {
     // Regression: lowercase b at position 0 was being case-folded to bishop ("b4+" -> "B4+") even when the
     // body shape is pawn-compatible. Should resolve to canonical "b4" with SPURIOUS_CHECK_SUFFIX.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("b4+");
+    final LenientSanParserValidationResult result = board.moveLenient("b4+");
     assertExactlyOneCode(result, LenientSanValidationProblem.SPURIOUS_CHECK_SUFFIX);
     assertEquals("b4", canonical(result));
   }
@@ -319,7 +319,7 @@ class TestLenientSanParser implements EnumConstants {
     // Regression: caseFixUppercaseFileLetters skipped position 0, so "E4" was rejected. Should resolve to
     // canonical "e4" with UPPERCASE_FILE_LETTER.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("E4");
+    final LenientSanParserValidationResult result = board.moveLenient("E4");
     assertExactlyOneCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
     assertEquals("e4", canonical(result));
   }
@@ -328,7 +328,7 @@ class TestLenientSanParser implements EnumConstants {
   void testUppercaseFileLetterAtPositionZeroUci() {
     // Regression: "E2E4" (UCI form with uppercase files) was rejected.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("E2E4");
+    final LenientSanParserValidationResult result = board.moveLenient("E2E4");
     assertContainsCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
     assertContainsCode(result, LenientSanValidationProblem.UCI_NOTATION);
     assertEquals("e4", canonical(result));
@@ -338,7 +338,7 @@ class TestLenientSanParser implements EnumConstants {
   void testUppercaseFileLetterAtPositionZeroLan() {
     // Regression: "E2-E4" (LAN form with uppercase files) was rejected.
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("E2-E4");
+    final LenientSanParserValidationResult result = board.moveLenient("E2-E4");
     assertContainsCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
     assertContainsCode(result, LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION);
     assertEquals("e4", canonical(result));
@@ -351,11 +351,11 @@ class TestLenientSanParser implements EnumConstants {
     // capture. Should resolve to canonical "Bxf7+" (the move is also check) with LOWERCASE_PIECE_LETTER and
     // MISSING_CHECK_SUFFIX.
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("e5");
-    board.performMove("Bc4");
-    board.performMove("Nc6");
-    final LenientSanParserValidationResult result = board.performMoveLenient("bxf7");
+    board.moveStrict("e4");
+    board.moveStrict("e5");
+    board.moveStrict("Bc4");
+    board.moveStrict("Nc6");
+    final LenientSanParserValidationResult result = board.moveLenient("bxf7");
     assertContainsCode(result, LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
     assertContainsCode(result, LenientSanValidationProblem.MISSING_CHECK_SUFFIX);
     assertEquals("Bxf7+", canonical(result));
@@ -368,7 +368,7 @@ class TestLenientSanParser implements EnumConstants {
     // UPPERCASE_FILE_LETTER and MISSING_PROMOTION_EQUALS. (Bishops don't promote, so uppercase B at the head
     // of a capture-promotion shape unambiguously means b-file pawn.)
     final Board board = new Board("r3k3/1P6/8/8/8/8/8/4K3 w - - 0 1");
-    final LenientSanParserValidationResult result = board.performMoveLenient("Bxa8Q");
+    final LenientSanParserValidationResult result = board.moveLenient("Bxa8Q");
     assertContainsCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
     assertContainsCode(result, LenientSanValidationProblem.MISSING_PROMOTION_EQUALS);
     assertEquals("bxa8=Q+", canonical(result));
@@ -379,9 +379,9 @@ class TestLenientSanParser implements EnumConstants {
     // Regression: pawn captures missing the 'x' (e.g. "ed5" after 1.e4 d5) were rejected, despite the spec
     // documenting MISSING_CAPTURE_MARKER without a piece-only caveat. Should resolve to canonical "exd5".
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("d5");
-    final LenientSanParserValidationResult result = board.performMoveLenient("ed5");
+    board.moveStrict("e4");
+    board.moveStrict("d5");
+    final LenientSanParserValidationResult result = board.moveLenient("ed5");
     assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_CAPTURE_MARKER);
     assertEquals("exd5", canonical(result));
   }
@@ -394,8 +394,8 @@ class TestLenientSanParser implements EnumConstants {
   void testCombinationLowercasePieceAndOverspecifiedFile() {
     // After 1.e4, black plays "nbc6" — lowercase n + unnecessary file disambig.
     final Board board = new Board();
-    board.performMove("e4");
-    final LenientSanParserValidationResult result = board.performMoveLenient("nbc6");
+    board.moveStrict("e4");
+    final LenientSanParserValidationResult result = board.moveLenient("nbc6");
     assertContainsCode(result, LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
     assertContainsCode(result, LenientSanValidationProblem.OVERSPECIFIED_FILE_DISAMBIGUATION);
     assertEquals("Nc6", canonical(result));
@@ -405,13 +405,13 @@ class TestLenientSanParser implements EnumConstants {
   void testCombinationZeroCastlingAndCheckSuffix() {
     // White castles kingside; the move isn't check, but written 0-0+ tests both forgiveness paths.
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("e5");
-    board.performMove("Nf3");
-    board.performMove("Nc6");
-    board.performMove("Bc4");
-    board.performMove("Bc5");
-    final LenientSanParserValidationResult result = board.performMoveLenient("0-0+");
+    board.moveStrict("e4");
+    board.moveStrict("e5");
+    board.moveStrict("Nf3");
+    board.moveStrict("Nc6");
+    board.moveStrict("Bc4");
+    board.moveStrict("Bc5");
+    final LenientSanParserValidationResult result = board.moveLenient("0-0+");
     assertContainsCode(result, LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING);
     assertContainsCode(result, LenientSanValidationProblem.SPURIOUS_CHECK_SUFFIX);
     assertEquals("O-O", canonical(result));
@@ -421,7 +421,7 @@ class TestLenientSanParser implements EnumConstants {
   void testCombinationUciAndOverspecifiedSquare() {
     // 1.g1f3 — UCI knight move. After UCI translation gives "Ng1f3"; Phase 2 strips overspec to "Nf3".
     final Board board = new Board();
-    final LenientSanParserValidationResult result = board.performMoveLenient("g1f3");
+    final LenientSanParserValidationResult result = board.moveLenient("g1f3");
     assertContainsCode(result, LenientSanValidationProblem.UCI_NOTATION);
     assertContainsCode(result, LenientSanValidationProblem.OVERSPECIFIED_SQUARE_DISAMBIGUATION);
     assertEquals("Nf3", canonical(result));
@@ -434,32 +434,32 @@ class TestLenientSanParser implements EnumConstants {
   @Test
   void testRejectMixedZeroAndOCastling() {
     final Board board = new Board();
-    board.performMove("e4");
-    board.performMove("e5");
-    board.performMove("Nf3");
-    board.performMove("Nc6");
-    board.performMove("Bc4");
-    board.performMove("Bc5");
-    assertThrows(LenientSanParserValidationException.class, () -> board.performMoveLenient("0-O"));
+    board.moveStrict("e4");
+    board.moveStrict("e5");
+    board.moveStrict("Nf3");
+    board.moveStrict("Nc6");
+    board.moveStrict("Bc4");
+    board.moveStrict("Bc5");
+    assertThrows(LenientSanParserValidationException.class, () -> board.moveLenient("0-O"));
   }
 
   @Test
   void testRejectGarbageInput() {
     final Board board = new Board();
-    assertThrows(LenientSanParserValidationException.class, () -> board.performMoveLenient("xyz"));
+    assertThrows(LenientSanParserValidationException.class, () -> board.moveLenient("xyz"));
   }
 
   @Test
   void testRejectIllegalMove() {
     // From initial position, white cannot play Nf6 (no knight can reach f6 in one move).
     final Board board = new Board();
-    assertThrows(LenientSanParserValidationException.class, () -> board.performMoveLenient("Nf6"));
+    assertThrows(LenientSanParserValidationException.class, () -> board.moveLenient("Nf6"));
   }
 
   @Test
   void testRejectBlankInput() {
     final Board board = new Board();
-    assertThrows(LenientSanParserValidationException.class, () -> board.performMoveLenient(""));
+    assertThrows(LenientSanParserValidationException.class, () -> board.moveLenient(""));
   }
 
   // ---------------------------------------------------------------------------
@@ -470,7 +470,7 @@ class TestLenientSanParser implements EnumConstants {
     final Board ref = new Board();
     final List<String> uci = new ArrayList<>(sanMoves.size());
     for (final String san : sanMoves) {
-      ref.performMove(san);
+      ref.moveStrict(san);
       final LegalMove last = ref.getLastMove();
       final UciMove uciMove = UciMoveUtility.convertMoveSpecificationToUci(last.havingMove(), last.moveSpecification());
       uci.add(uciMove.text());

--- a/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
+++ b/src/test/java/com/dlb/chess/test/san/lenient/TestLenientSanParser.java
@@ -1,0 +1,439 @@
+package com.dlb.chess.test.san.lenient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.dlb.chess.board.Board;
+import com.dlb.chess.common.constants.EnumConstants;
+import com.dlb.chess.common.ucimove.utility.UciMoveUtility;
+import com.dlb.chess.model.LegalMove;
+import com.dlb.chess.model.UciMove;
+import com.dlb.chess.san.enums.LenientSanValidationProblem;
+import com.dlb.chess.san.exceptions.LenientSanParserValidationException;
+import com.dlb.chess.san.model.ForgivenItem;
+import com.dlb.chess.san.model.LenientSanParserValidationResult;
+
+@SuppressWarnings("static-method")
+class TestLenientSanParser implements EnumConstants {
+
+  // Italian-game opening that exercises pawn pushes, knight/bishop development, and castling.
+  // Castling is the only move whose canonical SAN, LAN, and UCI representations all differ — the rest
+  // give us pawn vs piece coverage in each notation form.
+  private static final String[] ITALIAN_OPENING_SAN = { "e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "O-O", "Nf6", "d3",
+      "d6" };
+
+  // ---------------------------------------------------------------------------
+  // Three full-game tests (canonical SAN / UCI / LAN end-to-end).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testCanonicalSanGameProducesNoForgivenItems() {
+    final Board board = new Board();
+    for (final String san : ITALIAN_OPENING_SAN) {
+      final LenientSanParserValidationResult result = board.performMoveLenient(san);
+      assertTrue(result.forgivenItems().isEmpty(), "Expected no forgiven items for canonical SAN move: " + san
+          + " (got " + result.forgivenItems() + ")");
+    }
+  }
+
+  @Test
+  void testGameInUciNotation() {
+    final String[] uciMoves = computeUciForms(ITALIAN_OPENING_SAN);
+    final Board board = new Board();
+    var sawUciCode = false;
+    for (var i = 0; i < uciMoves.length; i++) {
+      final String uci = uciMoves[i];
+      final LenientSanParserValidationResult result = board.performMoveLenient(uci);
+      if (containsCode(result, LenientSanValidationProblem.UCI_NOTATION)) {
+        sawUciCode = true;
+      }
+    }
+    assertTrue(sawUciCode, "Expected at least one UCI_NOTATION forgiven item across the UCI-form game");
+  }
+
+  @Test
+  void testGameInLanNotation() {
+    // Use the project's getLan() output, then ensure pawn-forward moves get a hyphen so they're
+    // unambiguously LAN (not UCI-equivalent).
+    final String[] sanMoves = ITALIAN_OPENING_SAN;
+    final Board ref = new Board();
+    final String[] lanMoves = new String[sanMoves.length];
+    for (var i = 0; i < sanMoves.length; i++) {
+      ref.performMove(sanMoves[i]);
+      lanMoves[i] = toUnambiguousLan(ref.getLan());
+    }
+
+    final Board board = new Board();
+    var sawLongAlgebraic = false;
+    for (var i = 0; i < lanMoves.length; i++) {
+      final LenientSanParserValidationResult result = board.performMoveLenient(lanMoves[i]);
+      if (containsCode(result, LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION)) {
+        sawLongAlgebraic = true;
+      }
+    }
+    assertTrue(sawLongAlgebraic, "Expected at least one LONG_ALGEBRAIC_NOTATION forgiven item across the LAN-form game");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-code tests (one per LenientSanValidationProblem value).
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testMissingCheckSuffix() {
+    // After 1.e4 e5 2.Bc4 Nc6, white's Bxf7+ is check (not mate).
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("e5");
+    board.performMove("Bc4");
+    board.performMove("Nc6");
+    final LenientSanParserValidationResult result = board.performMoveLenient("Bxf7");
+    assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_CHECK_SUFFIX);
+    assertEquals("Bxf7+", canonical(result));
+  }
+
+  @Test
+  void testMissingCheckmateSuffix() {
+    // Back-rank mate: white rook to a8 mates black king on g8.
+    final Board board = new Board("6k1/5ppp/8/8/8/8/8/R6K w - - 0 1");
+    final LenientSanParserValidationResult result = board.performMoveLenient("Ra8");
+    assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_CHECKMATE_SUFFIX);
+    assertEquals("Ra8#", canonical(result));
+  }
+
+  @Test
+  void testSpuriousCheckSuffix() {
+    // 1.e4+ — pawn push that's not a check.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("e4+");
+    assertExactlyOneCode(result, LenientSanValidationProblem.SPURIOUS_CHECK_SUFFIX);
+    assertEquals("e4", canonical(result));
+  }
+
+  @Test
+  void testSpuriousCheckmateSuffix() {
+    // 1.e4# — pawn push that's not mate.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("e4#");
+    assertExactlyOneCode(result, LenientSanValidationProblem.SPURIOUS_CHECKMATE_SUFFIX);
+    assertEquals("e4", canonical(result));
+  }
+
+  @Test
+  void testWrongCheckSuffixForCheckmate() {
+    // Back-rank mate written with + instead of #.
+    final Board board = new Board("6k1/5ppp/8/8/8/8/8/R6K w - - 0 1");
+    final LenientSanParserValidationResult result = board.performMoveLenient("Ra8+");
+    assertExactlyOneCode(result, LenientSanValidationProblem.WRONG_CHECK_SUFFIX_FOR_CHECKMATE);
+    assertEquals("Ra8#", canonical(result));
+  }
+
+  @Test
+  void testWrongCheckmateSuffixForCheck() {
+    // Bxf7 in Italian is check, not mate. Written with # instead of +.
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("e5");
+    board.performMove("Bc4");
+    board.performMove("Nc6");
+    final LenientSanParserValidationResult result = board.performMoveLenient("Bxf7#");
+    assertExactlyOneCode(result, LenientSanValidationProblem.WRONG_CHECKMATE_SUFFIX_FOR_CHECK);
+    assertEquals("Bxf7+", canonical(result));
+  }
+
+  @Test
+  void testMissingCaptureMarker() {
+    // After 1.e4 e5 2.Nf3 d6 3.Nxe5 — knight capture on e5. Lenient: "Ne5" without x.
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("e5");
+    board.performMove("Nf3");
+    board.performMove("d6");
+    final LenientSanParserValidationResult result = board.performMoveLenient("Ne5");
+    assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_CAPTURE_MARKER);
+    assertEquals("Nxe5", canonical(result));
+  }
+
+  @Test
+  void testSpuriousCaptureMarker() {
+    // 1.e4 e5 2.Bxc4 — bishop to c4 is not a capture (c4 is empty).
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("e5");
+    final LenientSanParserValidationResult result = board.performMoveLenient("Bxc4");
+    assertExactlyOneCode(result, LenientSanValidationProblem.SPURIOUS_CAPTURE_MARKER);
+    assertEquals("Bc4", canonical(result));
+  }
+
+  @Test
+  void testOverspecifiedFileDisambiguation() {
+    // After 1.e4, black plays "Nbc6" — only Nb8 can reach c6, file disambig is unnecessary.
+    final Board board = new Board();
+    board.performMove("e4");
+    final LenientSanParserValidationResult result = board.performMoveLenient("Nbc6");
+    assertExactlyOneCode(result, LenientSanValidationProblem.OVERSPECIFIED_FILE_DISAMBIGUATION);
+    assertEquals("Nc6", canonical(result));
+  }
+
+  @Test
+  void testOverspecifiedRankDisambiguation() {
+    // Single white knight on d5; "N5e7" is rank-disambiguated but rank not necessary.
+    final Board board = new Board("4k3/8/8/3N4/8/8/P7/4K3 w - - 0 1");
+    final LenientSanParserValidationResult result = board.performMoveLenient("N5e7");
+    assertExactlyOneCode(result, LenientSanValidationProblem.OVERSPECIFIED_RANK_DISAMBIGUATION);
+    assertEquals("Ne7", canonical(result));
+  }
+
+  @Test
+  void testNonStandardRankDisambiguation() {
+    // Two white rooks (d1 and a4); both can reach a1, but only the d1 rook is on rank 1.
+    // Canonical SAN: "Rda1" (file disambig). User input "R1a1" (rank disambig) uniquely identifies the move
+    // but is non-canonical — strict throws NON_STANDARD_SPECIFIED_RNBQ_RANK_INSTEAD_OF_FILE; lenient resolves to
+    // "Rda1" by board lookup.
+    final Board board = new Board("7k/8/8/8/R7/8/8/3R3K w - - 0 1");
+    final LenientSanParserValidationResult result = board.performMoveLenient("R1a1");
+    assertExactlyOneCode(result, LenientSanValidationProblem.NON_STANDARD_RANK_DISAMBIGUATION);
+    assertEquals("Rda1", canonical(result));
+  }
+
+  @Test
+  void testOverspecifiedSquareDisambiguation() {
+    // Single white knight on d5; "Nd5e7" is square-disambiguated (both file and rank unnecessary).
+    final Board board = new Board("4k3/8/8/3N4/8/8/P7/4K3 w - - 0 1");
+    final LenientSanParserValidationResult result = board.performMoveLenient("Nd5e7");
+    assertExactlyOneCode(result, LenientSanValidationProblem.OVERSPECIFIED_SQUARE_DISAMBIGUATION);
+    assertEquals("Ne7", canonical(result));
+  }
+
+  @Test
+  void testLongAlgebraicNotation() {
+    // 1.e2-e4 — pawn move with explicit from-square and hyphen.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("e2-e4");
+    assertContainsCode(result, LenientSanValidationProblem.LONG_ALGEBRAIC_NOTATION);
+    assertEquals("e4", canonical(result));
+  }
+
+  @Test
+  void testUciNotation() {
+    // 1.e2e4 — pawn UCI form (no hyphen, no piece letter).
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("e2e4");
+    assertExactlyOneCode(result, LenientSanValidationProblem.UCI_NOTATION);
+    assertEquals("e4", canonical(result));
+  }
+
+  @Test
+  void testZeroInsteadOfOCastling() {
+    // Set up castle-eligible position and play 0-0.
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("e5");
+    board.performMove("Nf3");
+    board.performMove("Nc6");
+    board.performMove("Bc4");
+    board.performMove("Bc5");
+    final LenientSanParserValidationResult result = board.performMoveLenient("0-0");
+    assertExactlyOneCode(result, LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING);
+    assertEquals("O-O", canonical(result));
+  }
+
+  @Test
+  void testExplicitPawnLetter() {
+    // 1.Pe4 — explicit pawn letter prefix.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("Pe4");
+    assertExactlyOneCode(result, LenientSanValidationProblem.EXPLICIT_PAWN_LETTER);
+    assertEquals("e4", canonical(result));
+  }
+
+  @Test
+  void testMissingPromotionEquals() {
+    // White pawn on a7, plays a8Q (no = symbol).
+    final Board board = new Board("8/P7/1k6/8/8/8/8/4K3 w - - 0 1");
+    final LenientSanParserValidationResult result = board.performMoveLenient("a8Q");
+    assertExactlyOneCode(result, LenientSanValidationProblem.MISSING_PROMOTION_EQUALS);
+    assertEquals("a8=Q", canonical(result));
+  }
+
+  @Test
+  void testLowercasePieceLetter() {
+    // 1.nf3 — lowercase knight letter.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("nf3");
+    assertExactlyOneCode(result, LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
+    assertEquals("Nf3", canonical(result));
+  }
+
+  @Test
+  void testUppercaseFileLetter() {
+    // 1.NF3 — uppercase file letter.
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("NF3");
+    assertExactlyOneCode(result, LenientSanValidationProblem.UPPERCASE_FILE_LETTER);
+    assertEquals("Nf3", canonical(result));
+  }
+
+  @Test
+  void testUppercaseCaptureMarker() {
+    // 1.e4 e5 2.Nf3 d6 3.NXe5 — uppercase X.
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("e5");
+    board.performMove("Nf3");
+    board.performMove("d6");
+    final LenientSanParserValidationResult result = board.performMoveLenient("NXe5");
+    assertExactlyOneCode(result, LenientSanValidationProblem.UPPERCASE_CAPTURE_MARKER);
+    assertEquals("Nxe5", canonical(result));
+  }
+
+  @Test
+  void testLowercasePromotionPiece() {
+    // White pawn on a7, plays a8=q (lowercase q).
+    final Board board = new Board("8/P7/1k6/8/8/8/8/4K3 w - - 0 1");
+    final LenientSanParserValidationResult result = board.performMoveLenient("a8=q");
+    assertExactlyOneCode(result, LenientSanValidationProblem.LOWERCASE_PROMOTION_PIECE);
+    assertEquals("a8=Q", canonical(result));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Combination tests — multiple codes on one move.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testCombinationLowercasePieceAndOverspecifiedFile() {
+    // After 1.e4, black plays "nbc6" — lowercase n + unnecessary file disambig.
+    final Board board = new Board();
+    board.performMove("e4");
+    final LenientSanParserValidationResult result = board.performMoveLenient("nbc6");
+    assertContainsCode(result, LenientSanValidationProblem.LOWERCASE_PIECE_LETTER);
+    assertContainsCode(result, LenientSanValidationProblem.OVERSPECIFIED_FILE_DISAMBIGUATION);
+    assertEquals("Nc6", canonical(result));
+  }
+
+  @Test
+  void testCombinationZeroCastlingAndCheckSuffix() {
+    // White castles kingside; the move isn't check, but written 0-0+ tests both forgiveness paths.
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("e5");
+    board.performMove("Nf3");
+    board.performMove("Nc6");
+    board.performMove("Bc4");
+    board.performMove("Bc5");
+    final LenientSanParserValidationResult result = board.performMoveLenient("0-0+");
+    assertContainsCode(result, LenientSanValidationProblem.ZERO_INSTEAD_OF_O_CASTLING);
+    assertContainsCode(result, LenientSanValidationProblem.SPURIOUS_CHECK_SUFFIX);
+    assertEquals("O-O", canonical(result));
+  }
+
+  @Test
+  void testCombinationUciAndOverspecifiedSquare() {
+    // 1.g1f3 — UCI knight move. After UCI translation gives "Ng1f3"; Phase 2 strips overspec to "Nf3".
+    final Board board = new Board();
+    final LenientSanParserValidationResult result = board.performMoveLenient("g1f3");
+    assertContainsCode(result, LenientSanValidationProblem.UCI_NOTATION);
+    assertContainsCode(result, LenientSanValidationProblem.OVERSPECIFIED_SQUARE_DISAMBIGUATION);
+    assertEquals("Nf3", canonical(result));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hard rejection tests.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void testRejectMixedZeroAndOCastling() {
+    final Board board = new Board();
+    board.performMove("e4");
+    board.performMove("e5");
+    board.performMove("Nf3");
+    board.performMove("Nc6");
+    board.performMove("Bc4");
+    board.performMove("Bc5");
+    assertThrows(LenientSanParserValidationException.class, () -> board.performMoveLenient("0-O"));
+  }
+
+  @Test
+  void testRejectGarbageInput() {
+    final Board board = new Board();
+    assertThrows(LenientSanParserValidationException.class, () -> board.performMoveLenient("xyz"));
+  }
+
+  @Test
+  void testRejectIllegalMove() {
+    // From initial position, white cannot play Nf6 (no knight can reach f6 in one move).
+    final Board board = new Board();
+    assertThrows(LenientSanParserValidationException.class, () -> board.performMoveLenient("Nf6"));
+  }
+
+  @Test
+  void testRejectBlankInput() {
+    final Board board = new Board();
+    assertThrows(LenientSanParserValidationException.class, () -> board.performMoveLenient(""));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers.
+  // ---------------------------------------------------------------------------
+
+  private static String[] computeUciForms(String[] sanMoves) {
+    final Board ref = new Board();
+    final String[] uci = new String[sanMoves.length];
+    for (var i = 0; i < sanMoves.length; i++) {
+      ref.performMove(sanMoves[i]);
+      final LegalMove last = ref.getLastMove();
+      final UciMove uciMove = UciMoveUtility.convertMoveSpecificationToUci(last.havingMove(), last.moveSpecification());
+      uci[i] = uciMove.text();
+    }
+    return uci;
+  }
+
+  private static String toUnambiguousLan(String lanForm) {
+    // Castling: same in LAN and SAN.
+    if (lanForm.startsWith("O")) {
+      return lanForm;
+    }
+    // Pawn forward (length 4, file/rank/file/rank) is identical to UCI; insert a hyphen to disambiguate.
+    if (lanForm.length() == 4 && isFileLetter(lanForm.charAt(0)) && isRankDigit(lanForm.charAt(1))
+        && isFileLetter(lanForm.charAt(2)) && isRankDigit(lanForm.charAt(3))) {
+      return lanForm.substring(0, 2) + "-" + lanForm.substring(2);
+    }
+    // Other LAN forms (piece letter present, or pawn capture with x) are already distinct from UCI.
+    return lanForm;
+  }
+
+  private static boolean isFileLetter(char c) {
+    return c >= 'a' && c <= 'h';
+  }
+
+  private static boolean isRankDigit(char c) {
+    return c >= '1' && c <= '8';
+  }
+
+  private static boolean containsCode(LenientSanParserValidationResult result, LenientSanValidationProblem code) {
+    return result.forgivenItems().stream().anyMatch(item -> item.code() == code);
+  }
+
+  private static void assertContainsCode(LenientSanParserValidationResult result, LenientSanValidationProblem code) {
+    assertTrue(containsCode(result, code),
+        "Expected forgiven items to contain " + code + " but got " + result.forgivenItems());
+  }
+
+  private static void assertExactlyOneCode(LenientSanParserValidationResult result,
+      LenientSanValidationProblem expectedCode) {
+    assertEquals(1, result.forgivenItems().size(),
+        "Expected exactly one forgiven item with code " + expectedCode + " but got " + result.forgivenItems());
+    final ForgivenItem item = result.forgivenItems().get(0);
+    assertEquals(expectedCode, item.code(),
+        "Expected forgiven code " + expectedCode + " but got " + item.code());
+  }
+
+  private static String canonical(LenientSanParserValidationResult result) {
+    assertFalse(result.forgivenItems().isEmpty(),
+        "Cannot extract canonical SAN from a result with no forgiven items");
+    return result.forgivenItems().get(0).canonicalSan();
+  }
+}

--- a/src/test/java/com/dlb/chess/test/san/lenient/package-info.java
+++ b/src/test/java/com/dlb/chess/test/san/lenient/package-info.java
@@ -1,0 +1,4 @@
+@NonNullByDefault
+package com.dlb.chess.test.san.lenient;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/src/test/java/com/dlb/chess/test/san/move/TestSanValidateCastling.java
+++ b/src/test/java/com/dlb/chess/test/san/move/TestSanValidateCastling.java
@@ -10,7 +10,7 @@ import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.enums.CastlingCheck;
 import com.dlb.chess.san.exceptions.SanValidationException;
 import com.dlb.chess.san.validate.CastlingCheckMapper;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateCastling {
 
@@ -20,7 +20,7 @@ class TestSanValidateCastling {
   @Test
   void testNoRightKingMoved() {
     final ChessBoard board = new Board();
-    board.performMoves("e4", "e5", "Ke2", "d6", "Ke1", "d5");
+    board.movesStrict("e4", "e5", "Ke2", "d6", "Ke1", "d5");
     checkCastlingException("O-O", board, CastlingCheck.FINAL_NO_RIGHT,
         CastlingRightLoss.KING_MOVED);
     checkCastlingException("O-O-O", board, CastlingCheck.FINAL_NO_RIGHT,
@@ -33,7 +33,7 @@ class TestSanValidateCastling {
   @Test
   void testNoRightKingSideRookMoved() {
     final ChessBoard board = new Board();
-    board.performMoves("h4", "e5", "Rh3", "d6", "Rh1", "d5");
+    board.movesStrict("h4", "e5", "Rh3", "d6", "Rh1", "d5");
     checkCastlingException("O-O", board, CastlingCheck.FINAL_NO_RIGHT,
         CastlingRightLoss.ROOK_MOVED);
   }
@@ -42,8 +42,8 @@ class TestSanValidateCastling {
   @Test
   void testNoRightQueenSideRookMoved() {
     final ChessBoard board = new Board();
-    board.performMoves("a4", "e5", "Ra3", "d6", "Ra1", "d5");
-    board.performMoves("b3", "Nc6", "Bb2", "Be7", "Nc3", "Nf6", "Qc1", "a6");
+    board.movesStrict("a4", "e5", "Ra3", "d6", "Ra1", "d5");
+    board.movesStrict("b3", "Nc6", "Bb2", "Be7", "Nc3", "Nf6", "Qc1", "a6");
     checkCastlingException("O-O-O", board, CastlingCheck.FINAL_NO_RIGHT,
         CastlingRightLoss.ROOK_MOVED);
   }
@@ -66,7 +66,7 @@ class TestSanValidateCastling {
   @Test
   void testSquaresNotEmpty() {
     final ChessBoard board = new Board();
-    board.performMoves("e4");
+    board.movesStrict("e4");
     checkCastlingException("O-O", board, CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY,
         CastlingRightLoss.NOT_LOST);
     checkCastlingException("O-O-O", board, CastlingCheck.TEMPORARY_SQUARES_NOT_EMPTY,
@@ -105,7 +105,7 @@ class TestSanValidateCastling {
   private static void checkCastlingException(String san, ChessBoard board, CastlingCheck expectedCastlingCheck,
       CastlingRightLoss expectedLoss) {
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       throw new AssertionError("Expected SanValidationException");
     } catch (final SanValidationException e) {
       assertEquals(CastlingCheckMapper.map(expectedCastlingCheck, expectedLoss), e.getSanValidationProblem());

--- a/src/test/java/com/dlb/chess/test/san/move/TestSanValidateKingLegal.java
+++ b/src/test/java/com/dlb/chess/test/san/move/TestSanValidateKingLegal.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateKingLegal {
 
@@ -57,7 +57,7 @@ class TestSanValidateKingLegal {
   private static void checkException(String san, ChessBoard board, SanValidationProblem expectedProblem) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/move/TestSanValidateKingPseudoLegal.java
+++ b/src/test/java/com/dlb/chess/test/san/move/TestSanValidateKingPseudoLegal.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateKingPseudoLegal {
 
@@ -57,7 +57,7 @@ class TestSanValidateKingPseudoLegal {
   private static void checkException(String san, ChessBoard board, SanValidationProblem expectedProblem) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqFilePseudoLegal.java
+++ b/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqFilePseudoLegal.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateRnbqFilePseudoLegal {
 
@@ -116,7 +116,7 @@ class TestSanValidateRnbqFilePseudoLegal {
   private static void checkException(String san, ChessBoard board, SanValidationProblem expectedProblem) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqNeitherLegal.java
+++ b/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqNeitherLegal.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateRnbqNeitherLegal {
 
@@ -30,7 +30,7 @@ class TestSanValidateRnbqNeitherLegal {
     checkException(board, "Qxd8", SanValidationProblem.NOT_REACHABLE_RNBQ_NEITHER_SINGLE);
 
     // black
-    board.performMoves("e4");
+    board.movesStrict("e4");
     checkException(board, "Ra6", SanValidationProblem.NOT_REACHABLE_RNBQ_NEITHER_MULTIPLE);
     checkException(board, "Ne5", SanValidationProblem.NOT_REACHABLE_RNBQ_NEITHER_MULTIPLE);
     checkException(board, "Bg4", SanValidationProblem.NOT_REACHABLE_RNBQ_NEITHER_MULTIPLE);
@@ -50,62 +50,62 @@ class TestSanValidateRnbqNeitherLegal {
 
     // white
     // white rook
-    board.performMoves("a4", "a5", "h4", "h5", "Ra3", "Ra6");
+    board.movesStrict("a4", "a5", "h4", "h5", "Ra3", "Ra6");
     checkException(board, "Rh3", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("Rah3");
+    board.moveStrict("Rah3");
     // black rook
     checkException(board, "Rh6", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("Rah6");
+    board.moveStrict("Rah6");
 
     // white knight
-    board.performMoves("Nc3", "Nc6", "Nf3", "Nf6", "Nd4", "Nd5");
+    board.movesStrict("Nc3", "Nc6", "Nf3", "Nf6", "Nd4", "Nd5");
     checkException(board, "Nb5", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("Ncb5");
+    board.moveStrict("Ncb5");
     // black knight
     checkException(board, "Nb4", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("Ncb4");
+    board.moveStrict("Ncb4");
 
     // white bishop
-    board.performMoves("f4", "c5", "f5", "c4", "f6", "c3", "fxg7", "cxb2", "gxh8=B", "e6", "d3", "Bd6", "Bd2", "Ke7",
+    board.movesStrict("f4", "c5", "f5", "c4", "f6", "c3", "fxg7", "cxb2", "gxh8=B", "e6", "d3", "Bd6", "Bd2", "Ke7",
         "Qa1", "bxa1=B", "Bxh6", "Bxd4");
     checkException(board, "Bg7", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("B6g7");
+    board.moveStrict("B6g7");
     // black bishop
     checkException(board, "Be5", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("B4e5");
+    board.moveStrict("B4e5");
 
     // white queen
-    board.performMoves("c4", "f5", "cxd5", "f4", "dxe6", "f3", "exd7", "fxg2", "dxc8=Q", "gxh1=Q", "d4", "Qe4", "dxe5",
+    board.movesStrict("c4", "f5", "cxd5", "f4", "dxe6", "f3", "exd7", "fxg2", "dxc8=Q", "gxh1=Q", "d4", "Qe4", "dxe5",
         "Kf7", "exd6");
     checkException(board, "Qxh4+", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("Qdxh4+");
-    board.performMoves("Kd1", "Na2", "d7", "Nb4", "d8=Q", "Nc2", "Na7", "Kg6", "Nb5", "Kh7", "Qdc7");
+    board.moveStrict("Qdxh4+");
+    board.movesStrict("Kd1", "Na2", "d7", "Nb4", "d8=Q", "Nc2", "Na7", "Kg6", "Nb5", "Kh7", "Qdc7");
     // black queen
     checkException(board, "Qf4", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("Qhf4");
+    board.moveStrict("Qhf4");
     // white queen
     checkException(board, "Qd7", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("Q8d7");
-    board.performMoves("Qfe3", "Qf7");
+    board.moveStrict("Q8d7");
+    board.movesStrict("Qfe3", "Qf7");
     // black queen
     checkException(board, "Qf4", SanValidationProblem.INSUFFICIENTLY_SPECIFIED_RNBQ_NEITHER_EITHER_FILE_OR_RANK_OR_SQUARE_REQUIRED);
 
-    board.performMove("Q4f4");
+    board.moveStrict("Q4f4");
   }
 
   private static void checkException(ChessBoard board, String san, SanValidationProblem expectedValidation) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqNeitherPseudoLegal.java
+++ b/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqNeitherPseudoLegal.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateRnbqNeitherPseudoLegal {
 
@@ -130,7 +130,7 @@ class TestSanValidateRnbqNeitherPseudoLegal {
   private static void checkException(String san, ChessBoard board, SanValidationProblem expectedProblem) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqRankPseudoLegal.java
+++ b/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqRankPseudoLegal.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateRnbqRankPseudoLegal {
 
@@ -114,7 +114,7 @@ class TestSanValidateRnbqRankPseudoLegal {
   private static void checkException(String san, ChessBoard board, SanValidationProblem expectedProblem) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqSquarePseudoLegal.java
+++ b/src/test/java/com/dlb/chess/test/san/move/TestSanValidateRnbqSquarePseudoLegal.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidateRnbqSquarePseudoLegal {
 
@@ -70,7 +70,7 @@ class TestSanValidateRnbqSquarePseudoLegal {
   private static void checkException(String san, ChessBoard board, SanValidationProblem expectedProblem) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnCapturingDiagonal.java
+++ b/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnCapturingDiagonal.java
@@ -10,7 +10,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidatePawnCapturingDiagonal {
 
@@ -149,7 +149,7 @@ class TestSanValidatePawnCapturingDiagonal {
   private static void checkValid(String san, ChessBoard board) {
     var isException = false;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
     } catch (@SuppressWarnings("unused") final SanValidationException e) {
       isException = true;
     }
@@ -159,7 +159,7 @@ class TestSanValidatePawnCapturingDiagonal {
   private static void checkException(String san, ChessBoard board, SanValidationProblem svp) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnDestinationRank.java
+++ b/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnDestinationRank.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidatePawnDestinationRank {
 
@@ -54,7 +54,7 @@ class TestSanValidatePawnDestinationRank {
   private static void checkException(String san, ChessBoard board, SanValidationProblem svp) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnExists.java
+++ b/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnExists.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidatePawnExists {
 
@@ -77,7 +77,7 @@ class TestSanValidatePawnExists {
   private static void checkException(String san, ChessBoard board, SanValidationProblem svp) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnForwardMoves.java
+++ b/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnForwardMoves.java
@@ -9,7 +9,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidatePawnForwardMoves {
 
@@ -20,20 +20,20 @@ class TestSanValidatePawnForwardMoves {
     {
       final ChessBoard board = new Board();
 
-      board.performMove("d4");
-      board.performMove("d5");
+      board.moveStrict("d4");
+      board.moveStrict("d5");
       checkExceptionOpponent("d5", board);
     }
 
     {
       final ChessBoard board = new Board();
 
-      board.performMove("d4");
-      board.performMove("e5");
-      board.performMove("dxe5");
-      board.performMove("a6");
-      board.performMove("e4");
-      board.performMove("a5");
+      board.moveStrict("d4");
+      board.moveStrict("e5");
+      board.moveStrict("dxe5");
+      board.moveStrict("a6");
+      board.moveStrict("e4");
+      board.moveStrict("a5");
       checkExceptionOwn("e5", board);
     }
   }
@@ -45,22 +45,22 @@ class TestSanValidatePawnForwardMoves {
     {
       final ChessBoard board = new Board();
 
-      board.performMove("d4");
-      board.performMove("d5");
-      board.performMove("a3");
+      board.moveStrict("d4");
+      board.moveStrict("d5");
+      board.moveStrict("a3");
       checkExceptionOpponent("d4", board);
     }
 
     {
       final ChessBoard board = new Board();
 
-      board.performMove("d4");
-      board.performMove("e5");
-      board.performMove("a3");
-      board.performMove("exd4");
-      board.performMove("a4");
-      board.performMove("d5");
-      board.performMove("a5");
+      board.moveStrict("d4");
+      board.moveStrict("e5");
+      board.moveStrict("a3");
+      board.moveStrict("exd4");
+      board.moveStrict("a4");
+      board.moveStrict("d5");
+      board.moveStrict("a5");
       checkExceptionOwn("d4", board);
     }
   }
@@ -76,7 +76,7 @@ class TestSanValidatePawnForwardMoves {
   private static void checkException(String san, ChessBoard board, SanValidationProblem svp) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnFromSquare.java
+++ b/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnFromSquare.java
@@ -10,7 +10,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidatePawnFromSquare {
 
@@ -96,16 +96,16 @@ class TestSanValidatePawnFromSquare {
   void testNonCapturingTwoSquareWhiteAlreadyAdvanced() {
     {
       final ChessBoard board = new Board(FEN_BASE);
-      board.performMove("d4");
-      board.performMove("f5");
+      board.moveStrict("d4");
+      board.moveStrict("f5");
       checkException("d4", board, SanValidationProblem.DESTINATION_PAWN_FORWARD_OWN_PIECE);
     }
     {
       final ChessBoard board = new Board(FEN_BASE);
-      board.performMove("d4");
-      board.performMove("f5");
-      board.performMove("d5");
-      board.performMove("f4");
+      board.moveStrict("d4");
+      board.moveStrict("f5");
+      board.moveStrict("d5");
+      board.moveStrict("f4");
       checkException("d4", board, SanValidationProblem.NOT_REACHABLE_PAWN_NON_CAPTURING);
     }
   }
@@ -131,19 +131,19 @@ class TestSanValidatePawnFromSquare {
   void testNonCapturingTwoSquareBlackAlreadyAdvanced() {
     {
       final ChessBoard board = new Board(FEN_BASE);
-      board.performMove("d4");
-      board.performMove("f5");
-      board.performMove("d5");
+      board.moveStrict("d4");
+      board.moveStrict("f5");
+      board.moveStrict("d5");
       checkException("f5", board, SanValidationProblem.DESTINATION_PAWN_FORWARD_OWN_PIECE);
     }
 
     {
       final ChessBoard board = new Board(FEN_BASE);
-      board.performMove("d4");
-      board.performMove("f5");
-      board.performMove("d5");
-      board.performMove("f4");
-      board.performMove("d6");
+      board.moveStrict("d4");
+      board.moveStrict("f5");
+      board.moveStrict("d5");
+      board.moveStrict("f4");
+      board.moveStrict("d6");
       checkException("f5", board, SanValidationProblem.NOT_REACHABLE_PAWN_NON_CAPTURING);
     }
 
@@ -194,7 +194,7 @@ class TestSanValidatePawnFromSquare {
   private static void checkValid(String san, ChessBoard board) {
     var isException = false;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
     } catch (@SuppressWarnings("unused") final SanValidationException e) {
       isException = true;
     }
@@ -204,7 +204,7 @@ class TestSanValidatePawnFromSquare {
   private static void checkException(String san, ChessBoard board, SanValidationProblem svp) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnPromotion.java
+++ b/src/test/java/com/dlb/chess/test/san/pawn/TestSanValidatePawnPromotion.java
@@ -10,7 +10,7 @@ import com.dlb.chess.board.Board;
 import com.dlb.chess.common.interfaces.ChessBoard;
 import com.dlb.chess.san.enums.SanValidationProblem;
 import com.dlb.chess.san.exceptions.SanValidationException;
-import com.dlb.chess.san.validate.SanValidation;
+import com.dlb.chess.san.validate.StrictSanParser;
 
 class TestSanValidatePawnPromotion {
 
@@ -147,7 +147,7 @@ class TestSanValidatePawnPromotion {
   private static void checkValid(String san, ChessBoard board) {
     var isException = false;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
     } catch (@SuppressWarnings("unused") final SanValidationException e) {
       isException = true;
     }
@@ -157,7 +157,7 @@ class TestSanValidatePawnPromotion {
   private static void checkException(String san, ChessBoard board, SanValidationProblem svp) {
     boolean isException;
     try {
-      SanValidation.validateSan(san, board);
+      StrictSanParser.parseText(san, board);
       isException = false;
     } catch (final SanValidationException e) {
       isException = true;

--- a/src/test/java/com/dlb/chess/test/scalachess/GenerateScalaChessTestCases.java
+++ b/src/test/java/com/dlb/chess/test/scalachess/GenerateScalaChessTestCases.java
@@ -141,7 +141,7 @@ public class GenerateScalaChessTestCases implements EnumConstants {
         for (var i = 0; i < halfMoveList.size(); i++) {
           final HalfMove halfMove = NonNullWrapperCommon.get(halfMoveList, i);
 
-          boardPlayAlong.performMove(halfMove.moveSpecification());
+          boardPlayAlong.move(halfMove.moveSpecification());
           final var isMadeByWhite = halfMove.havingMove().getIsWhite();
           if (isMadeByWhite && halfMove.fullMoveNumber() % PRINT_MOVES_INTERVAL == 0) {
             final var moveDescription = halfMove.fullMoveNumber() + "." + halfMove.san();
@@ -223,7 +223,7 @@ public class GenerateScalaChessTestCases implements EnumConstants {
     }
     final Board board = new Board();
     for (final PgnHalfMove move : pgnFile.halfMoveList()) {
-      board.performMove(move.san());
+      board.moveStrict(move.san());
       System.out.println(calculateScalaMove(board.getLastMove().havingMove(), board.getLastMove().moveSpecification()));
     }
   }

--- a/src/test/java/com/dlb/chess/test/special/TestSpecialCastling.java
+++ b/src/test/java/com/dlb/chess/test/special/TestSpecialCastling.java
@@ -19,8 +19,8 @@ class TestSpecialCastling implements EnumConstants {
       // try queen side castling
       final ChessBoard board = new Board("4k3/8/8/8/8/8/8/R3K2R w K - 0 100");
 
-      assertTrue(board.performMove("O-O"));
-      board.unperformMove();
+      board.moveStrict("O-O");
+      board.unmove();
 
       checkException(board, "O-O-O");
     }
@@ -29,8 +29,8 @@ class TestSpecialCastling implements EnumConstants {
       // try king side castling
       final ChessBoard board = new Board("4k3/8/8/8/8/8/8/R3K2R w Q - 0 100");
 
-      assertTrue(board.performMove("O-O-O"));
-      board.unperformMove();
+      board.moveStrict("O-O-O");
+      board.unmove();
 
       checkException(board, "O-O");
     }
@@ -44,8 +44,8 @@ class TestSpecialCastling implements EnumConstants {
       // try queen side castling
       final ChessBoard board = new Board("r3k2r/8/8/8/8/8/8/R3K2R b k - 0 100");
 
-      assertTrue(board.performMove("O-O"));
-      board.unperformMove();
+      board.moveStrict("O-O");
+      board.unmove();
 
       checkException(board, "O-O-O");
     }
@@ -54,8 +54,8 @@ class TestSpecialCastling implements EnumConstants {
       // try king side castling
       final ChessBoard board = new Board("r3k2r/8/8/8/8/8/8/R3K2R b q - 0 100");
 
-      assertTrue(board.performMove("O-O-O"));
-      board.unperformMove();
+      board.moveStrict("O-O-O");
+      board.unmove();
 
       checkException(board, "O-O");
     }
@@ -64,7 +64,7 @@ class TestSpecialCastling implements EnumConstants {
   private static void checkException(ChessBoard board, String san) {
     var isCorrectException = false;
     try {
-      board.performMove(san);
+      board.moveStrict(san);
     } catch (@SuppressWarnings("unused") final SanValidationException sve) {
       isCorrectException = true;
     }

--- a/src/test/java/com/dlb/chess/test/special/TestSpecialPawnCapture.java
+++ b/src/test/java/com/dlb/chess/test/special/TestSpecialPawnCapture.java
@@ -18,13 +18,13 @@ class TestSpecialPawnCapture implements EnumConstants {
     // caused a bug
     final ChessBoard board = new Board("rrrrrrrr/PPPPPPPP/8/8/8/8/8/2k1K3 w - - 0 100");
 
-    assertTrue(board.performMove("bxa8=Q"));
-    board.unperformMove();
-    assertTrue(board.performMove("bxc8=Q"));
-    board.unperformMove();
+    board.moveStrict("bxa8=Q");
+    board.unmove();
+    board.moveStrict("bxc8=Q");
+    board.unmove();
 
-    assertTrue(board.performMove("cxd8=Q"));
-    board.unperformMove();
+    board.moveStrict("cxd8=Q");
+    board.unmove();
 
     checkException(board, "exd8=Q");
   }
@@ -36,13 +36,13 @@ class TestSpecialPawnCapture implements EnumConstants {
     // caused a bug
     final ChessBoard board = new Board("3k1K2/8/8/8/8/8/pppppppp/QQQQQQQQ b - - 0 100");
 
-    assertTrue(board.performMove("bxa1=Q"));
-    board.unperformMove();
-    assertTrue(board.performMove("bxc1=Q"));
-    board.unperformMove();
+    board.moveStrict("bxa1=Q");
+    board.unmove();
+    board.moveStrict("bxc1=Q");
+    board.unmove();
 
-    assertTrue(board.performMove("fxe1=Q"));
-    board.unperformMove();
+    board.moveStrict("fxe1=Q");
+    board.unmove();
 
     checkException(board, "dxe1=Q");
 
@@ -51,7 +51,7 @@ class TestSpecialPawnCapture implements EnumConstants {
   private static void checkException(ChessBoard board, String san) {
     var isCorrectException = false;
     try {
-      board.performMove(san);
+      board.moveStrict(san);
     } catch (@SuppressWarnings("unused") final SanValidationException sve) {
       isCorrectException = true;
     }

--- a/src/test/java/com/dlb/chess/test/validatenewmove/AbstractTestValidateNewMove.java
+++ b/src/test/java/com/dlb/chess/test/validatenewmove/AbstractTestValidateNewMove.java
@@ -15,7 +15,7 @@ public abstract class AbstractTestValidateNewMove implements EnumConstants {
   static void check(ChessBoard board, MoveSpecification move, MoveCheck expectedMoveCheck) {
     var isException = false;
     try {
-      board.performMove(move);
+      board.move(move);
     } catch (final InvalidMoveException e) {
       isException = true;
       assertEquals(expectedMoveCheck, e.getMoveCheck());

--- a/src/test/java/com/dlb/chess/test/validatenewmove/TestValidateNewMoveCastlingLost.java
+++ b/src/test/java/com/dlb/chess/test/validatenewmove/TestValidateNewMoveCastlingLost.java
@@ -17,7 +17,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testWhiteKingMoved() {
     final Board board = new Board();
-    board.performMoves("e4", "e5", "Ke2");
+    board.movesStrict("e4", "e5", "Ke2");
 
     assertEquals(CastlingRight.NONE, board.getCastlingRightWhite());
     assertEquals(CastlingRightLoss.KING_MOVED, board.getWhiteKingSideLoss());
@@ -28,7 +28,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testBlackKingMoved() {
     final Board board = new Board();
-    board.performMoves("e4", "e5", "Nf3", "Ke7");
+    board.movesStrict("e4", "e5", "Nf3", "Ke7");
 
     assertEquals(CastlingRight.NONE, board.getCastlingRightBlack());
     assertEquals(CastlingRightLoss.KING_MOVED, board.getBlackKingSideLoss());
@@ -41,7 +41,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testWhiteKingSideRookMoved() {
     final Board board = new Board();
-    board.performMoves("h4", "e5", "Rh3");
+    board.movesStrict("h4", "e5", "Rh3");
 
     assertEquals(CastlingRight.QUEEN_SIDE, board.getCastlingRightWhite());
     assertEquals(CastlingRightLoss.ROOK_MOVED, board.getWhiteKingSideLoss());
@@ -52,7 +52,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testBlackKingSideRookMoved() {
     final Board board = new Board();
-    board.performMoves("e4", "h5", "d4", "Rh6");
+    board.movesStrict("e4", "h5", "d4", "Rh6");
 
     assertEquals(CastlingRight.QUEEN_SIDE, board.getCastlingRightBlack());
     assertEquals(CastlingRightLoss.ROOK_MOVED, board.getBlackKingSideLoss());
@@ -65,7 +65,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testWhiteQueenSideRookMoved() {
     final Board board = new Board();
-    board.performMoves("a4", "e5", "Ra3");
+    board.movesStrict("a4", "e5", "Ra3");
 
     assertEquals(CastlingRight.KING_SIDE, board.getCastlingRightWhite());
     assertEquals(CastlingRightLoss.NOT_LOST, board.getWhiteKingSideLoss());
@@ -76,7 +76,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testBlackQueenSideRookMoved() {
     final Board board = new Board();
-    board.performMoves("e4", "a5", "d4", "Ra6");
+    board.movesStrict("e4", "a5", "d4", "Ra6");
 
     assertEquals(CastlingRight.KING_SIDE, board.getCastlingRightBlack());
     assertEquals(CastlingRightLoss.NOT_LOST, board.getBlackKingSideLoss());
@@ -89,7 +89,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testWhiteCastledKingSide() {
     final Board board = new Board();
-    board.performMoves("e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "O-O");
+    board.movesStrict("e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "O-O");
 
     assertEquals(CastlingRight.NONE, board.getCastlingRightWhite());
     assertEquals(CastlingRightLoss.CASTLED, board.getWhiteKingSideLoss());
@@ -100,7 +100,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testBlackCastledKingSide() {
     final Board board = new Board();
-    board.performMoves("e4", "e5", "Nf3", "Nf6", "Nc3", "Bc5", "Bc4", "O-O");
+    board.movesStrict("e4", "e5", "Nf3", "Nf6", "Nc3", "Bc5", "Bc4", "O-O");
 
     assertEquals(CastlingRight.NONE, board.getCastlingRightBlack());
     assertEquals(CastlingRightLoss.CASTLED, board.getBlackKingSideLoss());
@@ -113,7 +113,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testWhiteCastledQueenSide() {
     final Board board = new Board();
-    board.performMoves("d4", "d5", "Nc3", "Nc6", "Bf4", "Bf5", "Qd2", "Qd7", "O-O-O");
+    board.movesStrict("d4", "d5", "Nc3", "Nc6", "Bf4", "Bf5", "Qd2", "Qd7", "O-O-O");
 
     assertEquals(CastlingRight.NONE, board.getCastlingRightWhite());
     assertEquals(CastlingRightLoss.CASTLED, board.getWhiteKingSideLoss());
@@ -124,7 +124,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   @Test
   void testBlackCastledQueenSide() {
     final Board board = new Board();
-    board.performMoves("e4", "d5", "d4", "Nc6", "Nf3", "Bf5", "Nc3", "Qd7", "Bc4", "O-O-O");
+    board.movesStrict("e4", "d5", "d4", "Nc6", "Nf3", "Bf5", "Nc3", "Qd7", "Bc4", "O-O-O");
 
     assertEquals(CastlingRight.NONE, board.getCastlingRightBlack());
     assertEquals(CastlingRightLoss.CASTLED, board.getBlackKingSideLoss());
@@ -182,7 +182,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   void testBlackKingSideRookCapturedByWhite() {
     // White bishop goes Bb2-xg7-xh8, capturing black's h8 rook. Black king never moves.
     final Board board = new Board();
-    board.performMoves("b3", "a5", "Bb2", "a4", "Bxg7", "a3", "Bxh8");
+    board.movesStrict("b3", "a5", "Bb2", "a4", "Bxg7", "a3", "Bxh8");
 
     assertEquals(CastlingRight.QUEEN_SIDE, board.getCastlingRightBlack());
     assertEquals(CastlingRightLoss.ROOK_CAPTURED, board.getBlackKingSideLoss());
@@ -194,7 +194,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   void testBlackQueenSideRookCapturedByWhite() {
     // White pawn marches a-file and promotes on a8 capturing the rook.
     final Board board = new Board();
-    board.performMoves("a4", "b5", "axb5", "c5", "b6", "c4", "b7", "c3", "bxa8=Q");
+    board.movesStrict("a4", "b5", "axb5", "c5", "b6", "c4", "b7", "c3", "bxa8=Q");
 
     assertEquals(CastlingRight.KING_SIDE, board.getCastlingRightBlack());
     assertEquals(CastlingRightLoss.NOT_LOST, board.getBlackKingSideLoss());
@@ -206,7 +206,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
   void testWhiteKingSideRookCapturedByBlack() {
     // Mirror of black king-side test: black bishop goes Bb7-xg2-xh1.
     final Board board = new Board();
-    board.performMoves("a3", "b6", "a4", "Bb7", "a5", "Bxg2", "a6", "Bxh1");
+    board.movesStrict("a3", "b6", "a4", "Bb7", "a5", "Bxg2", "a6", "Bxh1");
 
     assertEquals(CastlingRight.QUEEN_SIDE, board.getCastlingRightWhite());
     assertEquals(CastlingRightLoss.ROOK_CAPTURED, board.getWhiteKingSideLoss());
@@ -220,7 +220,7 @@ class TestValidateNewMoveCastlingLost implements EnumConstants {
     // Instead: black bishop goes via Bb4-xa3... no. Simpler: use Bc3-xa1 path.
     // Black bishop goes Bf8-b4-a3...no. Let me use: black queen captures a1 rook.
     final Board board = new Board();
-    board.performMoves("h3", "a5", "h4", "a4", "h5", "a3", "h6", "axb2", "hxg7", "bxa1=Q");
+    board.movesStrict("h3", "a5", "h4", "a4", "h5", "a3", "h6", "axb2", "hxg7", "bxa1=Q");
 
     assertEquals(CastlingRight.KING_SIDE, board.getCastlingRightWhite());
     assertEquals(CastlingRightLoss.NOT_LOST, board.getWhiteKingSideLoss());

--- a/src/test/java/com/dlb/chess/test/validatenewmove/TestValidateNewMoveGameEnded.java
+++ b/src/test/java/com/dlb/chess/test/validatenewmove/TestValidateNewMoveGameEnded.java
@@ -81,7 +81,7 @@ class TestValidateNewMoveGameEnded implements EnumConstants {
     final ChessBoard board = new Board();
     // Sequence: 1.Nf3 Nf6 2.Ng1 Ng8 3.Nf3 Nf6 4.Ng1 Ng8 5.Nf3 Nf6 6.Ng1 Ng8 7.Nf3 Nf6 8.Ng1 Ng8
     // After move 8...Ng8 the starting position has occurred 5 times (move 0, 2, 4, 6, 8).
-    board.performMoves("Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8", "Nf3",
+    board.movesStrict("Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8", "Nf3", "Nf6", "Ng1", "Ng8", "Nf3",
         "Nf6", "Ng1", "Ng8");
     check(board, new MoveSpecification(E2, E4), GameStatus.FIVE_FOLD_REPETITION_RULE);
   }
@@ -91,7 +91,7 @@ class TestValidateNewMoveGameEnded implements EnumConstants {
   private static void check(ChessBoard board, MoveSpecification move, GameStatus expectedGameStatus) {
     var isException = false;
     try {
-      board.performMove(move);
+      board.move(move);
     } catch (final InvalidMoveException e) {
       isException = true;
       assertEquals(MoveCheck.GAME_ALREADY_ENDED, e.getMoveCheck());

--- a/src/test/java/com/dlb/chess/test/winnable/WinnableCalculateGameState.java
+++ b/src/test/java/com/dlb/chess/test/winnable/WinnableCalculateGameState.java
@@ -21,14 +21,14 @@ public class WinnableCalculateGameState {
 
     for (final LegalMove firstHalfMove : board.getLegalMoveSet()) {
       countEvaluatedPositions++;
-      board.performMove(firstHalfMove.moveSpecification());
+      board.move(firstHalfMove.moveSpecification());
       final GameStatus moveEvaluation = BasicChessUtility.calculateGameStatus(board);
       if (addMoveEvaluationMadeTheMove(moveEvaluation, gameStatusSet)) {
         // early return for found other, only interested in game ended or insufficient material oppponent
-        board.unperformMove();
+        board.unmove();
         return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
       }
-      board.unperformMove();
+      board.unmove();
     }
     return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
   }
@@ -40,14 +40,14 @@ public class WinnableCalculateGameState {
 
     for (final LegalMove firstHalfMove : board.getLegalMoveSet()) {
       countEvaluatedPositions++;
-      board.performMove(firstHalfMove.moveSpecification());
+      board.move(firstHalfMove.moveSpecification());
       final GameStatus moveEvaluation = BasicChessUtility.calculateGameStatus(board);
       if (addMoveEvaluationNotMadeTheMove(moveEvaluation, gameStatusSet)) {
         // early return for found other, only interested in game ended or insufficient material oppponent
-        board.unperformMove();
+        board.unmove();
         return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
       }
-      board.unperformMove();
+      board.unmove();
     }
     return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
   }
@@ -59,27 +59,27 @@ public class WinnableCalculateGameState {
 
     for (final LegalMove firstHalfMove : board.getLegalMoveSet()) {
       countEvaluatedPositions++;
-      board.performMove(firstHalfMove.moveSpecification());
+      board.move(firstHalfMove.moveSpecification());
       // If the first move creates a FIDE-automatic termination, the strict pipeline rejects
       // any further move from this position. The terminal status is already informative for
       // the analyzer; skip deeper exploration from this branch.
       if (BasicChessUtility.calculateGameStatus(board).isAutomaticTermination()) {
-        board.unperformMove();
+        board.unmove();
         continue;
       }
       for (final LegalMove secondHalfMove : board.getLegalMoveSet()) {
         countEvaluatedPositions++;
-        board.performMove(secondHalfMove.moveSpecification());
+        board.move(secondHalfMove.moveSpecification());
         final GameStatus moveEvaluation = BasicChessUtility.calculateGameStatus(board);
         if (addMoveEvaluationMadeTheMove(moveEvaluation, gameStatusSet)) {
           // early return for found other, only interested in game ended or insufficient material oppponent
-          board.unperformMove();
-          board.unperformMove();
+          board.unmove();
+          board.unmove();
           return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
         }
-        board.unperformMove();
+        board.unmove();
       }
-      board.unperformMove();
+      board.unmove();
     }
 
     return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
@@ -92,25 +92,25 @@ public class WinnableCalculateGameState {
 
     for (final LegalMove firstHalfMove : board.getLegalMoveSet()) {
       countEvaluatedPositions++;
-      board.performMove(firstHalfMove.moveSpecification());
+      board.move(firstHalfMove.moveSpecification());
       if (BasicChessUtility.calculateGameStatus(board).isAutomaticTermination()) {
-        board.unperformMove();
+        board.unmove();
         continue;
       }
       for (final LegalMove secondHalfMove : board.getLegalMoveSet()) {
 
         countEvaluatedPositions++;
-        board.performMove(secondHalfMove.moveSpecification());
+        board.move(secondHalfMove.moveSpecification());
         final GameStatus moveEvaluation = BasicChessUtility.calculateGameStatus(board);
         if (addMoveEvaluationNotMadeTheMove(moveEvaluation, gameStatusSet)) {
           // early return for found other, only interested in game ended or insufficient material oppponent
-          board.unperformMove();
-          board.unperformMove();
+          board.unmove();
+          board.unmove();
           return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
         }
-        board.unperformMove();
+        board.unmove();
       }
-      board.unperformMove();
+      board.unmove();
     }
 
     return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
@@ -123,35 +123,35 @@ public class WinnableCalculateGameState {
 
     for (final LegalMove firstHalfMove : board.getLegalMoveSet()) {
       countEvaluatedPositions++;
-      board.performMove(firstHalfMove.moveSpecification());
+      board.move(firstHalfMove.moveSpecification());
       if (BasicChessUtility.calculateGameStatus(board).isAutomaticTermination()) {
-        board.unperformMove();
+        board.unmove();
         continue;
       }
       for (final LegalMove secondHalfMove : board.getLegalMoveSet()) {
         countEvaluatedPositions++;
-        board.performMove(secondHalfMove.moveSpecification());
+        board.move(secondHalfMove.moveSpecification());
         if (BasicChessUtility.calculateGameStatus(board).isAutomaticTermination()) {
-          board.unperformMove();
+          board.unmove();
           continue;
         }
         for (final LegalMove thirdHalfMove : board.getLegalMoveSet()) {
 
           countEvaluatedPositions++;
-          board.performMove(thirdHalfMove.moveSpecification());
+          board.move(thirdHalfMove.moveSpecification());
           final GameStatus moveEvaluation = BasicChessUtility.calculateGameStatus(board);
           if (addMoveEvaluationMadeTheMove(moveEvaluation, gameStatusSet)) {
             // early return for found other, only interested in game ended or insufficient material oppponent
-            board.unperformMove();
-            board.unperformMove();
-            board.unperformMove();
+            board.unmove();
+            board.unmove();
+            board.unmove();
             return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
           }
-          board.unperformMove();
+          board.unmove();
         }
-        board.unperformMove();
+        board.unmove();
       }
-      board.unperformMove();
+      board.unmove();
     }
 
     return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
@@ -164,35 +164,35 @@ public class WinnableCalculateGameState {
 
     for (final LegalMove firstHalfMove : board.getLegalMoveSet()) {
       countEvaluatedPositions++;
-      board.performMove(firstHalfMove.moveSpecification());
+      board.move(firstHalfMove.moveSpecification());
       if (BasicChessUtility.calculateGameStatus(board).isAutomaticTermination()) {
-        board.unperformMove();
+        board.unmove();
         continue;
       }
       for (final LegalMove secondHalfMove : board.getLegalMoveSet()) {
         countEvaluatedPositions++;
-        board.performMove(secondHalfMove.moveSpecification());
+        board.move(secondHalfMove.moveSpecification());
         if (BasicChessUtility.calculateGameStatus(board).isAutomaticTermination()) {
-          board.unperformMove();
+          board.unmove();
           continue;
         }
         for (final LegalMove thirdHalfMove : board.getLegalMoveSet()) {
 
           countEvaluatedPositions++;
-          board.performMove(thirdHalfMove.moveSpecification());
+          board.move(thirdHalfMove.moveSpecification());
           final GameStatus moveEvaluation = BasicChessUtility.calculateGameStatus(board);
           if (addMoveEvaluationNotMadeTheMove(moveEvaluation, gameStatusSet)) {
             // early return for found other, only interested in game ended or insufficient material oppponent
-            board.unperformMove();
-            board.unperformMove();
-            board.unperformMove();
+            board.unmove();
+            board.unmove();
+            board.unmove();
             return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
           }
-          board.unperformMove();
+          board.unmove();
         }
-        board.unperformMove();
+        board.unmove();
       }
-      board.unperformMove();
+      board.unmove();
     }
 
     return new EvaluatePositions(gameStatusSet, countEvaluatedPositions);
@@ -205,7 +205,7 @@ public class WinnableCalculateGameState {
     while (board.getLegalMoveSet().size() == 1) {
       countForcedHalfMoves++;
       final LegalMove legalMove = SetUtility.getOnly(board.getLegalMoveSet());
-      board.performMove(legalMove.moveSpecification());
+      board.move(legalMove.moveSpecification());
       final GameStatus evaluation = BasicChessUtility.calculateGameStatus(board);
       switch (BasicChessUtility.calculateGameStatus(board)) {
         case CHECKMATE:
@@ -217,7 +217,7 @@ public class WinnableCalculateGameState {
         case STALEMATE:
           final Side sideMadeLastMove = board.getHavingMove().getOppositeSide();
           for (var i = 1; i <= countForcedHalfMoves; i++) {
-            board.unperformMove();
+            board.unmove();
           }
           return new GameForced(evaluation, countForcedHalfMoves, sideMadeLastMove);
         case ONGOING:
@@ -229,7 +229,7 @@ public class WinnableCalculateGameState {
 
     final Side sideMadeLastMove = board.getHavingMove().getOppositeSide();
     for (var i = 1; i <= countForcedHalfMoves; i++) {
-      board.unperformMove();
+      board.unmove();
     }
     return new GameForced(GameStatus.ONGOING, countForcedHalfMoves, sideMadeLastMove);
   }

--- a/src/test/java/com/dlb/chess/test/winnable/lichess/WinnableUtilityAnalyzeChaLichess.java
+++ b/src/test/java/com/dlb/chess/test/winnable/lichess/WinnableUtilityAnalyzeChaLichess.java
@@ -134,7 +134,7 @@ public class WinnableUtilityAnalyzeChaLichess {
       var isKingOnlyFlagging = "na";
       if (numberOfFirstHalfMoves == 1) {
         final LegalMove legalMove = SetUtility.getOnly(board.getLegalMoveSet());
-        board.performMove(legalMove.moveSpecification());
+        board.move(legalMove.moveSpecification());
         if (MaterialUtility.calculateHasKingOnly(board.getHavingMove(), board.getStaticPosition())) {
           isKingOnlyNonFlagging = "yes";
         } else {
@@ -145,7 +145,7 @@ public class WinnableUtilityAnalyzeChaLichess {
         } else {
           isKingOnlyFlagging = "no";
         }
-        board.unperformMove();
+        board.unmove();
       }
 
       logResult(IS_DEBUG, "first;" + evaluationFirst.numberOfHalfMoves(), winnableFirst, board, sideToEvaluate,
@@ -158,10 +158,10 @@ public class WinnableUtilityAnalyzeChaLichess {
 
     // only one move, perform the move and see what's next, then unperform!
     final LegalMove legalMove = SetUtility.getOnly(board.getLegalMoveSet());
-    board.performMove(legalMove.moveSpecification());
+    board.move(legalMove.moveSpecification());
     final var numberOfSecondHalfMoves = board.getLegalMoveSet().size();
     final GameMultipleAnalysis evaluationSecond = evaluateOneMove(board);
-    board.unperformMove();
+    board.unmove();
     final WinnableAnalysis winnableSecond = calculateWinnableMultiple(evaluationSecond, sideToEvaluate);
     boolean isReturnSecond;
     if (numberOfSecondHalfMoves >= 2) {
@@ -310,7 +310,7 @@ public class WinnableUtilityAnalyzeChaLichess {
     final Side sidePerformingTheMove = board.getHavingMove();
 
     for (final LegalMove legalMove : board.getLegalMoveSet()) {
-      board.performMove(legalMove.moveSpecification());
+      board.move(legalMove.moveSpecification());
       if (board.isCheckmate()) {
         switch (sidePerformingTheMove) {
           case WHITE -> gameTermination.add(GameStatusAnalysis.WHITE_DELIVERS_CHECKMATE);
@@ -333,7 +333,7 @@ public class WinnableUtilityAnalyzeChaLichess {
       } else {
         gameTermination.add(GameStatusAnalysis.OTHER);
       }
-      board.unperformMove();
+      board.unmove();
     }
 
     return new GameMultipleAnalysis(gameTermination, numberOfHalfMoves, board.getHavingMove());
@@ -347,7 +347,7 @@ public class WinnableUtilityAnalyzeChaLichess {
     while (board.getLegalMoveSet().size() == 1) {
       countForcedHalfMoves++;
       final LegalMove legalMove = SetUtility.getOnly(board.getLegalMoveSet());
-      board.performMove(legalMove.moveSpecification());
+      board.move(legalMove.moveSpecification());
       evaluation = calculateGameStatusAnalysis(board, sideToEvaluate);
       if (evaluation != GameStatusAnalysis.OTHER) {
         break;
@@ -356,7 +356,7 @@ public class WinnableUtilityAnalyzeChaLichess {
 
     // undo moves
     for (var i = 1; i <= countForcedHalfMoves; i++) {
-      board.unperformMove();
+      board.unmove();
     }
 
     return new GameForcedAnalysis(evaluation, countForcedHalfMoves);

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/01_missing_check_suffix.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/01_missing_check_suffix.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e4 e5 2. Bc4 Nc6 3. Bxf7 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/02_missing_checkmate_suffix.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/02_missing_checkmate_suffix.pgn
@@ -1,0 +1,11 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+[SetUp "1"]
+[FEN "6k1/5ppp/8/8/8/8/8/R6K w - - 0 1"]
+
+1. Ra8 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/03_spurious_check_suffix.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/03_spurious_check_suffix.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e4+ *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/04_spurious_checkmate_suffix.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/04_spurious_checkmate_suffix.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e4# *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/05_wrong_check_suffix_for_checkmate.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/05_wrong_check_suffix_for_checkmate.pgn
@@ -1,0 +1,11 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+[SetUp "1"]
+[FEN "6k1/5ppp/8/8/8/8/8/R6K w - - 0 1"]
+
+1. Ra8+ *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/06_wrong_checkmate_suffix_for_check.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/06_wrong_checkmate_suffix_for_check.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e4 e5 2. Bc4 Nc6 3. Bxf7# *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/07_missing_capture_marker.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/07_missing_capture_marker.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 d6 3. Ne5 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/08_spurious_capture_marker.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/08_spurious_capture_marker.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e4 e5 2. Bxc4 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/09_overspecified_file_disambiguation.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/09_overspecified_file_disambiguation.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e4 Nbc6 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/10_overspecified_rank_disambiguation.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/10_overspecified_rank_disambiguation.pgn
@@ -1,0 +1,11 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+[SetUp "1"]
+[FEN "4k3/8/8/3N4/8/8/P7/4K3 w - - 0 1"]
+
+1. N5e7 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/11_overspecified_square_disambiguation.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/11_overspecified_square_disambiguation.pgn
@@ -1,0 +1,11 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+[SetUp "1"]
+[FEN "4k3/8/8/3N4/8/8/P7/4K3 w - - 0 1"]
+
+1. Nd5e7 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/12_non_standard_rank_disambiguation.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/12_non_standard_rank_disambiguation.pgn
@@ -1,0 +1,11 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+[SetUp "1"]
+[FEN "7k/8/8/8/R7/8/8/3R3K w - - 0 1"]
+
+1. R1a1 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/13_long_algebraic_notation.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/13_long_algebraic_notation.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e2-e4 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/14_uci_notation.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/14_uci_notation.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e2e4 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/15_zero_instead_of_o_castling.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/15_zero_instead_of_o_castling.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. 0-0 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/16_explicit_pawn_letter.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/16_explicit_pawn_letter.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. Pe4 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/17_missing_promotion_equals.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/17_missing_promotion_equals.pgn
@@ -1,0 +1,11 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+[SetUp "1"]
+[FEN "8/P7/1k6/8/8/8/8/4K3 w - - 0 1"]
+
+1. a8Q *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/18_lowercase_piece_letter.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/18_lowercase_piece_letter.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. nf3 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/19_uppercase_file_letter.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/19_uppercase_file_letter.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. NF3 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/20_uppercase_capture_marker.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/20_uppercase_capture_marker.pgn
@@ -1,0 +1,9 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 d6 3. NXe5 *

--- a/src/test/resources/pgnParser/lenient/sanForgivenItems/21_lowercase_promotion_piece.pgn
+++ b/src/test/resources/pgnParser/lenient/sanForgivenItems/21_lowercase_promotion_piece.pgn
@@ -1,0 +1,11 @@
+[Event "?"]
+[Site "?"]
+[Date "?"]
+[Round "?"]
+[White "?"]
+[Black "?"]
+[Result "*"]
+[SetUp "1"]
+[FEN "8/P7/1k6/8/8/8/8/4K3 w - - 0 1"]
+
+1. a8=q *

--- a/tasks.md
+++ b/tasks.md
@@ -277,6 +277,41 @@ Whatever ships in the first Central artifact is in the public record forever. Re
 
 ---
 
+## Backlog — captured but unscheduled
+
+Items here are not assigned to any release. Captured so they don't get lost; revisit if/when scope or motivation aligns.
+
+### FEN parser tier audit and rename
+Three FEN parsers exist: `FenParserRaw`, `FenParserAdvanced`, `FenParserAdvancedFurther`. The third is largely unused. Boundaries between the three are unclear and the docs overclaim what each tier proves (see "FEN-validation documentation overclaims" below).
+- [ ] Audit each tier — what each parser actually validates vs what its docs claim
+- [ ] Document each tier's contract precisely in `specification.md`
+- [ ] Decide: keep three tiers, collapse `AdvancedFurther` into `Advanced`, or drop it
+
+### Replace `UciValidateHelper` enum with computed lookup
+Auto-generated 1984-line enum, ~111 KB class file (~50% of the JAR's bytecode mass). Used as a list-of-strings rather than as an enum. A generation loop in the static init of its only caller would replace 1984 lines of source with ~12.
+- [ ] Replace the enum with a `Set<String>` (or similar) computed via a constructor loop
+- [ ] Verify JAR shrinks by ~50%
+
+### FEN-validation documentation overclaims
+`fen/package-info.java` and `Board.java` (class-level + constructor docs) say advanced FEN rejects positions "no real game could reach." The code does strong structural and rule-consistency checks but does not prove full game reachability. Also: package text says halfmove clock "at or above 150" while code accepts exactly 150.
+- [ ] Soften prose to "advanced structural and rule-consistency validation"
+- [ ] List exactly what is enforced; drop the unsubstantiated reachability claim
+- [ ] Fix the "at or above" off-by-one
+
+### Broken Javadoc link in `fen/package-info.java`
+Links to `com.dlb.chess.fen.FenParser` which does not exist. `mvn javadoc:jar` succeeds only because `<doclint>none</doclint>` in pom.xml; the warning is still emitted. Real target is `FenParserRaw` + `FenParserAdvanced`.
+- [ ] Fix the link
+
+### CHA / unwinnability wording teaches the wrong mental model
+README and `unwinnability/package-info.java` use "worst play / worst-case play by the opponent." In game-theory English, "worst-case opponent" reads like *best defensive play*, but CHA / winnability is the opposite: whether any legal continuation can lead to mate (cooperative / helpmate-style existence). Worth fixing because it is the flagship concept.
+- [ ] Rewrite around "no legal sequence exists, even with the opponent's cooperation" or "no theoretical mating sequence exists under any legal continuation"
+
+### README inconsistency — CHA full "100% accurate" vs `UNDETERMINED`
+README says CHA full is "slower but 100% accurate," then a few lines down documents the `UNDETERMINED` outcome (and again later in the doc).
+- [ ] Reword to "complete when it returns WINNABLE / UNWINNABLE; bounded search may return UNDETERMINED"
+
+---
+
 ## Done
 
 - [x] **README.md cleanup pass** (Java 17)

--- a/tasks.md
+++ b/tasks.md
@@ -310,6 +310,11 @@ README and `unwinnability/package-info.java` use "worst play / worst-case play b
 README says CHA full is "slower but 100% accurate," then a few lines down documents the `UNDETERMINED` outcome (and again later in the doc).
 - [ ] Reword to "complete when it returns WINNABLE / UNWINNABLE; bounded search may return UNDETERMINED"
 
+### Rename `NonNullWrapperCommon` to `Nulls`
+The class is used pervasively (every JDT-null-safe wrapper for JDK calls goes through it), and `NonNullWrapperCommon` is too long for something so frequent. `Nulls` is short, pronounceable, says the domain (this utility exists because of nullness handling), and discoverable in the IDE. Rejected alternatives: `NNVC` (cryptic codeword), `Safe` / `Checked` (vague), `NonNulls` (awkward plural).
+- [ ] Rename class `NonNullWrapperCommon` → `Nulls`; update all call sites (uses appear in most files in the project — bulk rename)
+- [ ] Verify the methods are still all about nullness handling; if any aren't, reconsider the name
+
 ---
 
 ## Done


### PR DESCRIPTION
## Summary

Adds the lenient SAN parser as a first-class feature, and renames the move-execution API so the strict / lenient choice is explicit at every call site.

The strict SAN pipeline is reused unchanged for chess validation; lenient is a thin input-shape transformer plus a recovery loop on top.

## Breaking

Source-incompatible rename across `Board`, the `ChessBoard` interface, and the strict SAN entry point. See [CHANGELOG](CHANGELOG.md#400---2026-05-10) for the migration table.

## Test plan

- [x] `mvn clean test` — 1029 / 0 / 4
- [x] `mvn javadoc:jar -DskipTests`
- [x] Three independent code-review rounds