### PR TITLE
README: bump dependency version to 7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Requires JDK 17 or later at runtime. Available via the [JitPack](https://jitpack
 <dependency>
   <groupId>com.github.dlbbld</groupId>
   <artifactId>clean-chess</artifactId>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
 </dependency>
 ```
 
@@ -56,7 +56,7 @@ repositories {
 ```groovy
 dependencies {
     ...
-    implementation 'com.github.dlbbld:clean-chess:6.0.0'
+    implementation 'com.github.dlbbld:clean-chess:7.0.0'
     ...
 }
 ```


### PR DESCRIPTION
Maven and Gradle dependency snippets updated from 6.0.0 to 7.0.0 to match the version shipped on pom.xml. Documentation-only follow-up to the 7.0.0 release; main was missed in the release branch.