### PR TITLE
15.0.0 release artifacts: pom + README + CHANGELOG + tasks.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Releases from 3.3 onward. Earlier history is in git tags only.
 
 ## [Unreleased]
 
+## [15.0.0] - 2026-05-26
+
 The **termination-is-information release**. The move pipeline no longer consults any game-end predicate: checkmate, stalemate, mutual insufficient material, fivefold repetition, the 75-move rule, and analyzer-driven dead positions are all surfaced as queryable artifacts the caller polls to decide whether to adjudicate. At checkmate and stalemate the natural barrier is the empty legal-move set (a move attempt fails through ordinary legality); at the other terminations legal moves still exist and the pipeline accepts them. The `GameStatus` enum is replaced by a structured `Outcome` record carrying `Termination` and the winner — python-chess parity at the API boundary, the cross-validation oracle that's been the project's reference since 12.2.0. The motivation: clean-chess corpus and tooling already needed to replay historical PGN that continues a move or two past an automatic termination, the python-chess oracle returns terminations as information rather than enforcement, and the previous in-pipeline gate forced ugly workarounds in both the oracle harness and the lenient parser. Dropping the gate eliminates the impedance mismatch.
 
 ### Notable

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Requires JDK 17 or later at runtime. Available via the [JitPack](https://jitpack
 <dependency>
   <groupId>com.github.dlbbld</groupId>
   <artifactId>clean-chess</artifactId>
-  <version>13.0.0</version>
+  <version>15.0.0</version>
 </dependency>
 ```
 
@@ -56,7 +56,7 @@ repositories {
 ```groovy
 dependencies {
     ...
-    implementation 'com.github.dlbbld:clean-chess:13.0.0'
+    implementation 'com.github.dlbbld:clean-chess:15.0.0'
     ...
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.github.dlbbld</groupId>
 	<artifactId>clean-chess</artifactId>
-	<version>14.0.0</version>
+	<version>15.0.0</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/tasks.md
+++ b/tasks.md
@@ -10,7 +10,32 @@ Order within each section is the source of truth. Completed tasks move to **Done
 
 ---
 
-## Current release — 14.0.0: drop auto-CHA-per-move; dead-position queries become request-based
+## Current release — 15.0.0: termination is information, not enforcement
+
+✅ Shipped 2026-05-26. The move-validation pipeline no longer consults any game-end predicate. Checkmate, stalemate,
+mutual insufficient material, fivefold repetition, the 75-move rule, and analyzer-driven dead positions are all
+queryable artifacts the caller polls. At checkmate / stalemate the empty legal-move set is the natural barrier; at the
+other terminations legal moves still exist and play continues until the caller adjudicates.
+
+The release also replaced the `GameStatus` enum with a structured `Outcome` record (`Outcome(Termination, @Nullable Side
+winner)` — python-chess parity), reordered precedence to match python-chess (`mate → IM → stale → 75 → fivefold`),
+aligned `isFiftyMove` / `isSeventyFiveMove` with python-chess and FIDE (require legal moves to exist), and unlocked the
+python-chess import oracle to run unguarded across all 35,001 plies in the corpus. The `canClaimFiftyMoveRuleWithOwnMove`
+predicate follows the strict FIDE 9.3 reading — one deliberate divergence from python-chess at a constructed corner
+case where the only non-zeroing legal move at clock 99 delivers mate. python-chess's behavior at that edge is
+collateral from code reuse (not from documented intent — verified against blame and the maintainer's own tests, which
+pin the current-position-is-mate case but not the candidate-move-is-mate case).
+
+Supporting work shipped in the same release: `Reporter` slimmed to print-only (`Report` record deleted); `PgnTestCase`
+reduced to `(pgnName, finalFen)` and renamed `PgnFen` with ~1,400 catalog entries rewritten; internal `HalfMove`
+slimmed; initial-position repetition bug fixed; doc passes through `specification.md` §3.1, the board package-info,
+and the relevant test JavaDoc.
+
+See `CHANGELOG.md` `[15.0.0]` for the full Notable / Behavioral / Breaking breakdown including migration snippets.
+
+---
+
+## Released — 14.0.0: drop auto-CHA-per-move; dead-position queries become request-based
 
 ✅ Shipped 2026-05-24. Analyzer-driven dead-position detection no longer runs automatically on construction or every
 move, `DEAD_POSITION_UNWINNABLE_QUICK` is reportable but non-blocking, and the boolean `Board` constructor/config
@@ -52,7 +77,7 @@ The fivefold / 75-move counterpart shipped in **13.0.0** (the *reallow-play-beyo
 
 ---
 
-## Future release — 15.0.0: make threefold and fifty-move report production grade and clean-up
+## Future release — 16.0.0: make threefold and fifty-move report production grade and clean-up
 
 Do not start this immediately after the current release. This section exists so the follow-up work is captured, scoped,
 and not rediscovered chaotically later.


### PR DESCRIPTION
## Summary

Version-bump PR for the termination-is-information release (merged on main in #56). Four files touched:

- **`pom.xml`** — `14.0.0` → `15.0.0`. Major bump per the project's pre-Central semver convention: this release deletes `GameStatus`, removes enum values from `MoveCheck` / `SanValidationProblem`, drops three-argument exception constructors across five exception types, deletes `BasicChessUtility.calculateGameStatus`, and changes the semantics of `isFiftyMove` / `isSeventyFiveMove`.
- **`README.md`** — Maven and Gradle dependency snippets `13.0.0` → `15.0.0`. The snippets had drifted from `pom.xml` at the 14.0.0 release (they still said 13.0.0); aligning them and bumping to 15.0.0 in one step.
- **`CHANGELOG.md`** — `[Unreleased]` heading promoted to `[15.0.0] - 2026-05-26` (today). A fresh empty `[Unreleased]` heading is kept at the top for future entries per Keep-A-Changelog convention. The two `Pre-15.0.0` / `Post-15.0.0` references in the Behavioral section are now self-consistent.
- **`tasks.md`** — New `## Current release — 15.0.0: termination is information, not enforcement` section added above the 14.0.0 section, with the release summary and a pointer at the CHANGELOG entry. The previous `## Current release — 14.0.0` heading demoted to `## Released — 14.0.0` (it's no longer the current/in-flight release). The previous `## Future release — 15.0.0: make threefold and fifty-move report production grade and clean-up` heading renumbered to `## Future release — 16.0.0` to make room for 15.0.0 taking the termination-is-information slot.

## Test plan

- [ ] `mvn -o compile` green on the bumped version (verified locally).
- [ ] `mvn test -Pfull` green from a clean checkout — required precondition for tag per `workflows.md`.
- [ ] Merge this PR to `main`.
- [ ] Tag `15.0.0` on the merge commit and push the tag: `git tag 15.0.0 && git push origin 15.0.0`.
- [ ] Confirm JitPack picks up the new tag at `https://jitpack.io/com/github/dlbbld/clean-chess/15.0.0/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)