### PR TITLE
Fix orphan fixture missing trailing empty line

### DIFF
--- a/src/test/resources/pgn/cha/various/01_cha_test_vector_orphan.pgn
+++ b/src/test/resources/pgn/cha/various/01_cha_test_vector_orphan.pgn
@@ -9,3 +9,4 @@
 [FEN "1b3kBR/4pP1P/1p1pP2P/1P1P4/8/K5p1/6P1/1B6 b - - 0 1"]
 
 *
+


### PR DESCRIPTION
Release pre-flight (5.4, `mvn test -Pfull`) on the merged 22.0.0 main found 1 failure + 5 errors, all one root cause: `01_cha_test_vector_orphan.pgn` was adopted into the strict-parsed corpus ending `*\n` instead of `*\n\n`, failing the strict pre-scan's exactly-two-empty-lines rule. The corpus-sweep tests that read it run only under `-Pfull`, which is why the default profile stayed green.

One byte appended; the corpus audit and the affected comparison tests are green again. Needed on main before tagging 22.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)