### PR TITLE
One-command release pre-flight and default-profile corpus lint

### DIFF
--- a/src/test/java/io/github/dlbbld/ashlarchess/pgn/TestPgnCorpusFileStructure.java
+++ b/src/test/java/io/github/dlbbld/ashlarchess/pgn/TestPgnCorpusFileStructure.java
@@ -1,0 +1,73 @@
+// Copyright (C) 2020-2026 Daniel Baechli
+// SPDX-License-Identifier: GPL-3.0-only
+
+package io.github.dlbbld.ashlarchess.pgn;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.dlbbld.ashlarchess.internal.Nulls;
+import io.github.dlbbld.ashlarchess.test.pgntest.constants.PgnTestConstants;
+
+/**
+ * Cheap structural lint over the whole strict PGN corpus, in the <em>default</em> profile. Every file under
+ * {@code src/test/resources/pgn/} must pass {@link StrictFileStructurePreScan} (the exactly-two-empty-lines rule and
+ * friends) - the corpus is strict-format by definition.
+ *
+ * <p>
+ * Motivation (22.0.0 pre-flight): a fixture adopted into the corpus ending {@code *\n} instead of {@code *\n\n} stayed
+ * invisible for a full day because every test that strict-parses the corpus lives in the {@code -Pfull} profile, and
+ * surfaced only at release pre-flight as 1 failure + 5 errors. Structure validation is O(file length) - the whole
+ * corpus costs a second or two - so it belongs in the default profile and fails the same commit that adds a malformed
+ * file. The expensive semantic sweeps (replay, oracle comparisons) stay in {@code -Pfull}.
+ *
+ * <p>
+ * Lives in the {@code pgn} package (not {@code test.pgn}) because {@link StrictFileStructurePreScan} is deliberately
+ * package-private: the lint checks file structure only, mirroring exactly what {@code StrictPgnParser.parseInternal}
+ * feeds it (LF-normalised source, no BOM strip - strict rejects BOMs by design).
+ */
+class TestPgnCorpusFileStructure {
+
+  @SuppressWarnings("static-method")
+  @Test
+  void everyCorpusFilePassesTheStrictStructurePreScan() throws IOException {
+    final Path corpusRoot = PgnTestConstants.PGN_TEST_ROOT_FOLDER_PATH;
+    final List<String> failures = new ArrayList<>();
+    int fileCount = 0;
+
+    try (Stream<Path> paths = Files.walk(corpusRoot)) {
+      final List<Path> pgnFiles = paths.filter(p -> Nulls.toString(p).endsWith(".pgn")).sorted().toList();
+      for (final Path pgnFile : pgnFiles) {
+        fileCount++;
+        final String source = new String(Files.readAllBytes(pgnFile), StandardCharsets.UTF_8);
+        try {
+          StrictFileStructurePreScan.validate(NewlineNormalization.toLf(source));
+        } catch (final StrictPgnParserValidationException e) {
+          failures.add(Nulls.toString(corpusRoot.relativize(pgnFile)) + "  -  " + e.getMessage());
+        }
+      }
+    }
+
+    if (fileCount == 0) {
+      fail("No corpus files found under " + corpusRoot + " - corpus root wiring is broken");
+    }
+    if (!failures.isEmpty()) {
+      final StringBuilder message = new StringBuilder();
+      message.append(failures.size()).append(" of ").append(fileCount)
+          .append(" corpus PGN files fail the strict file-structure pre-scan:\n");
+      for (final String failure : failures) {
+        message.append("  ").append(failure).append('\n');
+      }
+      fail(Nulls.toString(message));
+    }
+  }
+}

--- a/tasks.md
+++ b/tasks.md
@@ -13,6 +13,8 @@ Live planning only: current release work, backlog, and obsolete decisions. Shipp
 
 ## 22.0.0 — Unwinnability now straight from the FUN 2022 paper
 
+Published 2026-07-04 (tag `22.0.0` on `f04800f9`, on Maven Central); see **CHANGELOG.md** for the consumer-facing summary. Shipped from branch `implement-fun22` (merged as PR #68, plus the pre-flight fixture fix PR #69). The `fun22-reference` project is decommissioned with the release: everything of value is vendored and validated in ashlar, a full-history bundle lives in `Downloads/fun22-reference-archive/`.
+
 Branch `implement-fun22`. The unwinnability engine becomes ashlar's own clean-room implementation of Ambrona's FUN 2022
 paper (*A Practical Algorithm for Chess Unwinnability*, Figures 5–13, Lemmas 5/6, Theorem 12), vendored from the
 validated `fun22-reference` project (branch `semi-static-v1`: whole-corpus sweeps vs chasolver with 0 contradictions).

--- a/tools/build-release-notes.ps1
+++ b/tools/build-release-notes.ps1
@@ -1,0 +1,58 @@
+param(
+  [Parameter(Mandatory = $true)] [string] $Version,
+  [Parameter(Mandatory = $true)] [string] $Title,
+  [string] $OutFile
+)
+
+# Builds the GitHub Release notes body from the CHANGELOG.md [X.Y.Z] entry (runbook step 10).
+#
+# Why this exists (22.0.0 lesson): CHANGELOG.md is hard-wrapped at ~120 columns - a source-file
+# convention that is invisible when GitHub renders a FILE (single newlines reflow). But GitHub
+# renders RELEASE NOTES (and issues/comments) with hard newlines: a single \n becomes <br>. Pasting
+# the changelog entry verbatim therefore breaks every paragraph mid-sentence on the release page.
+# This script unwraps: each paragraph and each list item becomes one logical line; headings and
+# blank lines are preserved. Never hand-paste changelog text into a release body.
+#
+# Usage:
+#   .\tools\build-release-notes.ps1 -Version 22.0.0 -Title "Unwinnability now straight from the FUN 2022 paper"
+#   gh release create 22.0.0 --verify-tag --title "22.0.0" --notes-file release-notes-22.0.0.md
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$changelog = Get-Content (Join-Path $repoRoot "CHANGELOG.md") -Encoding UTF8
+
+# Extract the [X.Y.Z] entry body (between its header and the next release header).
+$body = New-Object System.Collections.Generic.List[string]
+$inEntry = $false
+foreach ($line in $changelog) {
+  if ($line -match "^## \[$([regex]::Escape($Version))\]") { $inEntry = $true; continue }
+  if ($inEntry -and $line -match "^## \[") { break }
+  if ($inEntry) { $body.Add($line) }
+}
+if ($body.Count -eq 0) {
+  Write-Error "No CHANGELOG.md entry found for version $Version."
+}
+
+# Unwrap: join continuation lines into one logical line per paragraph / list item.
+$out = New-Object System.Collections.Generic.List[string]
+$buffer = $null
+function Flush-Buffer {
+  if ($null -ne $script:buffer) { $script:out.Add($script:buffer); $script:buffer = $null }
+}
+foreach ($line in $body) {
+  if ($line.Trim() -eq "") { Flush-Buffer; $out.Add("") }
+  elseif ($line.StartsWith("#")) { Flush-Buffer; $out.Add($line) }
+  elseif ($line.TrimStart().StartsWith("- ")) { Flush-Buffer; $buffer = $line.TrimEnd() }
+  elseif ($null -ne $buffer) { $buffer = $buffer + " " + $line.Trim() }
+  else { $buffer = $line.TrimEnd() }
+}
+Flush-Buffer
+
+$notes = "# $Title`n`n" + (($out -join "`n").Trim() + "`n")
+
+if (-not $OutFile) { $OutFile = Join-Path $repoRoot "release-notes-$Version.md" }
+[System.IO.File]::WriteAllText($OutFile, $notes.Replace("`r`n", "`n"), (New-Object System.Text.UTF8Encoding($false)))
+Write-Host "Release notes written to $OutFile ($($out.Count + 1) logical lines)."
+Write-Host "Publish with: gh release create $Version --verify-tag --title `"$Version`" --notes-file `"$OutFile`""

--- a/tools/preflight.ps1
+++ b/tools/preflight.ps1
@@ -1,0 +1,86 @@
+param(
+  [switch] $SkipExcludedSuite
+)
+
+# Release pre-flight (workflows.md, "Cutting a release" step 5) as one fail-fast command.
+#
+# Gates, in order:
+#   1. worktree clean            (5.1)
+#   2. license headers exact     (5.2)
+#   3. mvn test -Pfull           (5.4)
+#   4. mvn test -Pfull -Dtest.excludes=   (5.5; skip with -SkipExcludedSuite for a quick pass)
+#   5. JavaDoc gates             (5.6): mvn clean javadoc:javadoc javadoc:test-javadoc -Dshow=private
+#
+# Every gate's verdict comes from the tool's own exit code - no log grepping, no shell masking. The
+# script stops at the first red gate and exits non-zero; a green run ends with an explicit summary.
+# 5.7 (tasks.md) and 5.8 (board burn-in decision) remain human steps by design.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+Set-Location $repoRoot
+
+$gates = New-Object System.Collections.Generic.List[string]
+$stopwatchTotal = [System.Diagnostics.Stopwatch]::StartNew()
+
+function Invoke-Gate {
+  param(
+    [string] $Name,
+    [scriptblock] $Body
+  )
+  Write-Host ""
+  Write-Host "=== GATE: $Name ===" -ForegroundColor Cyan
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  & $Body
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Host "PRE-FLIGHT FAILED at gate: $Name (exit $LASTEXITCODE, after $($sw.Elapsed.ToString('mm\:ss')))" -ForegroundColor Red
+    exit 1
+  }
+  $script:gates.Add(("{0,-42} PASS  {1}" -f $Name, $sw.Elapsed.ToString('mm\:ss')))
+}
+
+Invoke-Gate "5.1 worktree clean" {
+  $status = git status --porcelain
+  if ($status) {
+    Write-Host "Worktree is not clean:" -ForegroundColor Red
+    Write-Host $status
+    $global:LASTEXITCODE = 1
+  } else {
+    Write-Host "Worktree clean."
+    $global:LASTEXITCODE = 0
+  }
+}
+
+Invoke-Gate "5.2 license headers" {
+  & (Join-Path $PSScriptRoot "java-license-headers.ps1") -Check
+  # java-license-headers.ps1 uses Write-Error/exit on drift; reaching here cleanly means exact.
+  if ($null -eq $LASTEXITCODE) { $global:LASTEXITCODE = 0 }
+}
+
+Invoke-Gate "5.4 mvn test -Pfull" {
+  mvn test -Pfull
+}
+
+if (-not $SkipExcludedSuite) {
+  Invoke-Gate "5.5 mvn test -Pfull -Dtest.excludes=" {
+    mvn test -Pfull "-Dtest.excludes="
+  }
+} else {
+  Write-Host ""
+  Write-Host "=== GATE: 5.5 excluded unwinnability suite - SKIPPED on request ===" -ForegroundColor Yellow
+  $gates.Add(("{0,-42} SKIP" -f "5.5 mvn test -Pfull -Dtest.excludes="))
+}
+
+Invoke-Gate "5.6 JavaDoc gates" {
+  mvn clean javadoc:javadoc javadoc:test-javadoc "-Dshow=private"
+}
+
+Write-Host ""
+Write-Host "================ PRE-FLIGHT SUMMARY ================" -ForegroundColor Green
+foreach ($line in $gates) { Write-Host $line }
+Write-Host ("{0,-42} {1}" -f "total", $stopwatchTotal.Elapsed.ToString('hh\:mm\:ss'))
+Write-Host ""
+Write-Host "All automated gates green. Remaining human steps: 5.7 (tasks.md all done), 5.8 (board burn-in if board logic changed)." -ForegroundColor Green
+exit 0

--- a/tools/preflight.ps1
+++ b/tools/preflight.ps1
@@ -4,16 +4,23 @@ param(
 
 # Release pre-flight (workflows.md, "Cutting a release" step 5) as one fail-fast command.
 #
+# Gate ORDER is the point: cheap, likely-to-fail, fix-requires-a-commit gates run FIRST, the expensive
+# read-only suites LAST. Any fix committed after a gate invalidates every gate already passed (the
+# artifact you validate must be the artifact you ship), so a failure in a cheap late gate would force
+# re-running the 30-40 minute suites. Front-loading the mutation-prone gates makes that rare.
+#
 # Gates, in order:
-#   1. worktree clean            (5.1)
-#   2. license headers exact     (5.2)
-#   3. mvn test -Pfull           (5.4)
-#   4. mvn test -Pfull -Dtest.excludes=   (5.5; skip with -SkipExcludedSuite for a quick pass)
-#   5. JavaDoc gates             (5.6): mvn clean javadoc:javadoc javadoc:test-javadoc -Dshow=private
+#   1. worktree clean            (free; everything after assumes a committed tree)
+#   2. license headers exact     (seconds; a miss means a fix commit)
+#   3. JavaDoc gates             (~2 min; doc errors mean fix commits): mvn clean javadoc:javadoc javadoc:test-javadoc -Dshow=private
+#   4. mvn test -Pfull           (the long suite; read-only)
+#   5. mvn test -Pfull -Dtest.excludes=   (the excluded unwinnability suite; longest; read-only;
+#                                          skip with -SkipExcludedSuite for a quick pass)
 #
 # Every gate's verdict comes from the tool's own exit code - no log grepping, no shell masking. The
 # script stops at the first red gate and exits non-zero; a green run ends with an explicit summary.
-# 5.7 (tasks.md) and 5.8 (board burn-in decision) remain human steps by design.
+# If ANY gate forced a fix commit, re-run the script from the top on the new tree.
+# tasks.md confirmation and the board burn-in decision remain human steps by design.
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
@@ -41,7 +48,7 @@ function Invoke-Gate {
   $script:gates.Add(("{0,-42} PASS  {1}" -f $Name, $sw.Elapsed.ToString('mm\:ss')))
 }
 
-Invoke-Gate "5.1 worktree clean" {
+Invoke-Gate "worktree clean" {
   $status = git status --porcelain
   if ($status) {
     Write-Host "Worktree is not clean:" -ForegroundColor Red
@@ -53,28 +60,28 @@ Invoke-Gate "5.1 worktree clean" {
   }
 }
 
-Invoke-Gate "5.2 license headers" {
+Invoke-Gate "license headers" {
   & (Join-Path $PSScriptRoot "java-license-headers.ps1") -Check
   # java-license-headers.ps1 uses Write-Error/exit on drift; reaching here cleanly means exact.
   if ($null -eq $LASTEXITCODE) { $global:LASTEXITCODE = 0 }
 }
 
-Invoke-Gate "5.4 mvn test -Pfull" {
+Invoke-Gate "JavaDoc gates" {
+  mvn clean javadoc:javadoc javadoc:test-javadoc "-Dshow=private"
+}
+
+Invoke-Gate "mvn test -Pfull" {
   mvn test -Pfull
 }
 
 if (-not $SkipExcludedSuite) {
-  Invoke-Gate "5.5 mvn test -Pfull -Dtest.excludes=" {
+  Invoke-Gate "mvn test -Pfull -Dtest.excludes=" {
     mvn test -Pfull "-Dtest.excludes="
   }
 } else {
   Write-Host ""
-  Write-Host "=== GATE: 5.5 excluded unwinnability suite - SKIPPED on request ===" -ForegroundColor Yellow
-  $gates.Add(("{0,-42} SKIP" -f "5.5 mvn test -Pfull -Dtest.excludes="))
-}
-
-Invoke-Gate "5.6 JavaDoc gates" {
-  mvn clean javadoc:javadoc javadoc:test-javadoc "-Dshow=private"
+  Write-Host "=== GATE: excluded unwinnability suite - SKIPPED on request ===" -ForegroundColor Yellow
+  $gates.Add(("{0,-42} SKIP" -f "mvn test -Pfull -Dtest.excludes="))
 }
 
 Write-Host ""
@@ -82,5 +89,5 @@ Write-Host "================ PRE-FLIGHT SUMMARY ================" -ForegroundCol
 foreach ($line in $gates) { Write-Host $line }
 Write-Host ("{0,-42} {1}" -f "total", $stopwatchTotal.Elapsed.ToString('hh\:mm\:ss'))
 Write-Host ""
-Write-Host "All automated gates green. Remaining human steps: 5.7 (tasks.md all done), 5.8 (board burn-in if board logic changed)." -ForegroundColor Green
+Write-Host "All automated gates green. Remaining human steps: tasks.md all done, board burn-in if board logic changed." -ForegroundColor Green
 exit 0

--- a/workflows.md
+++ b/workflows.md
@@ -130,7 +130,7 @@ only when you need context.
 
 **5. Run pre-flight on the release branch**
 
-**5.1** Run the pre-flight script: `.\tools\preflight.ps1`. It chains, fail-fast with one summary and honest exit codes: worktree clean → license headers (`java-license-headers.ps1 -Check`) → `mvn test -Pfull` → `mvn test -Pfull -Dtest.excludes=` (the normally excluded unwinnability suite; a release exercises it) → the JavaDoc gates (`mvn clean javadoc:javadoc javadoc:test-javadoc -Dshow=private`).
+**5.1** Run the pre-flight script: `.\tools\preflight.ps1`. It chains, fail-fast with one summary and honest exit codes, **cheap fix-prone gates first, expensive read-only suites last**: worktree clean → license headers (`java-license-headers.ps1 -Check`) → the JavaDoc gates (`mvn clean javadoc:javadoc javadoc:test-javadoc -Dshow=private`) → `mvn test -Pfull` → `mvn test -Pfull -Dtest.excludes=` (the normally excluded unwinnability suite; a release exercises it). The order matters: a failed cheap gate means a fix commit, and a fix commit invalidates every gate already passed — front-loading the fix-prone gates keeps a header or doc slip from costing a 40-minute suite re-run. If any gate forced a commit, re-run the script from the top.
 
 **5.2** If the header gate reports drift, fix and commit: `.\tools\java-license-headers.ps1 -Fix`, then re-run 5.1.
 

--- a/workflows.md
+++ b/workflows.md
@@ -186,9 +186,9 @@ only when you need context.
 
 **10.2** Release title field: `X.Y.Z`.
 
-**10.3** Notes body starts with `# <release title>`.
+**10.3** Generate the notes body — never hand-paste changelog text: `.\tools\build-release-notes.ps1 -Version X.Y.Z -Title "<release title>"`. It emits `# <release title>` plus the `CHANGELOG.md` `[X.Y.Z]` entry with paragraphs and list items **unwrapped to one logical line each**. The changelog's ~120-column hard wraps are invisible in file rendering but become `<br>` in a release body (GitHub renders files with soft newlines, release notes/issues/comments with hard ones) — pasted verbatim, every paragraph breaks mid-sentence (22.0.0 lesson, fixed in place with `gh release edit`).
 
-**10.4** Paste/adapt the `CHANGELOG.md` `[X.Y.Z]` entry below that H1.
+**10.4** Publish: `gh release create X.Y.Z --verify-tag --title "X.Y.Z" --notes-file release-notes-X.Y.Z.md` — then **open the release page and look at it**.
 
 **11. Post-release**
 

--- a/workflows.md
+++ b/workflows.md
@@ -38,7 +38,7 @@ Run from Eclipse (Run As → Java Application) or from the command line:
 
 Find the `createTestCases<Category>` function matching the target `PgnTest` enum value in [`PgnTestCaseCatalog.java`](src/test/java/io/github/dlbbld/ashlarchess/test/pgn/setup/PgnTestCaseCatalog.java). Append the generated `list.add(...)` line in the natural sort order of the existing entries.
 
-Run `mvn test -Dtest=TestSetupPgnRegistration` to confirm the corpus-vs-registry diff is now empty.
+Run `mvn test -Dtest=TestSetupPgnRegistration` to confirm the corpus-vs-registry diff is now empty, and `mvn test -Dtest=TestPgnCorpusFileStructure` to confirm the file passes the strict file-structure pre-scan (exactly two empty lines: one after the last tag, one at the end). The structure lint runs in every default-profile build, so a malformed file fails the same commit that adds it — running it here just catches the mistake before it is even committed. (Lesson from 22.0.0: a corpus file ending `*\n` instead of `*\n\n` stayed invisible for a day because every corpus-sweeping test lived in `-Pfull`.)
 
 ### Adding a new corpus category
 
@@ -96,9 +96,11 @@ only when you need context.
 
 **2.4** Regenerate README/manual examples: `mvn -o -q test-compile exec:java -Dexec.mainClass=io.github.dlbbld.ashlarchess.test.readme.GenerateReadme -Dexec.classpathScope=test`.
 
-**2.5** Review the diff as mechanical only.
+**2.5** Run the JavaDoc gates: `mvn clean javadoc:javadoc javadoc:test-javadoc -Dshow=private`. Doc errors are cleanup-shaped and belong in this pass; pre-flight re-runs the same gate as a cheap confirmation.
 
-**2.6** Commit this cleanup separately before the version bump.
+**2.6** Review the diff as mechanical only.
+
+**2.7** Commit this cleanup separately before the version bump.
 
 **3. Choose the release title**
 
@@ -128,21 +130,13 @@ only when you need context.
 
 **5. Run pre-flight on the release branch**
 
-**5.1** Confirm the worktree is clean.
+**5.1** Run the pre-flight script: `.\tools\preflight.ps1`. It chains, fail-fast with one summary and honest exit codes: worktree clean → license headers (`java-license-headers.ps1 -Check`) → `mvn test -Pfull` → `mvn test -Pfull -Dtest.excludes=` (the normally excluded unwinnability suite; a release exercises it) → the JavaDoc gates (`mvn clean javadoc:javadoc javadoc:test-javadoc -Dshow=private`).
 
-**5.2** Check Java license headers: `.\tools\java-license-headers.ps1 -Check`.
+**5.2** If the header gate reports drift, fix and commit: `.\tools\java-license-headers.ps1 -Fix`, then re-run 5.1.
 
-**5.3** If needed, fix and commit header drift: `.\tools\java-license-headers.ps1 -Fix`.
+**5.3** Confirm all release tasks are done in `tasks.md`.
 
-**5.4** Run full tests: `mvn test -Pfull`.
-
-**5.5** Also exercise the normally excluded unwinnability package for a release: `mvn test -Pfull -Dtest.excludes=`.
-
-**5.6** Run JavaDoc gates from a clean `target/`: `mvn clean javadoc:javadoc javadoc:test-javadoc -Dshow=private`.
-
-**5.7** Confirm all release tasks are done in `tasks.md`.
-
-**5.8** If board logic changed materially, run the board burn-in and update the baseline: `mvn -o -q exec:java -Dexec.classpathScope=test -Dexec.mainClass=io.github.dlbbld.ashlarchess.test.performance.BoardApiBurnInSurvey`.
+**5.4** If board logic changed materially, run the board burn-in and update the baseline: `mvn -o -q exec:java -Dexec.classpathScope=test -Dexec.mainClass=io.github.dlbbld.ashlarchess.test.performance.BoardApiBurnInSurvey`.
 
 **6. Run the release build dry-run on the branch**
 
@@ -251,6 +245,8 @@ Browse prior entries in `CHANGELOG.md` for tone and depth. Entries before this c
 `## [X.Y.Z] - YYYY-MM-DD` header with no title; leave them as shipped.
 
 #### 5. Run pre-flight on the release branch
+
+Pre-flight is one command — `.\tools\preflight.ps1` — chaining the five automated gates fail-fast, each verdict taken from the tool's own exit code (no log grepping; a build failure can never hide behind a green shell exit). The notes below explain the individual gates.
 
 The pre-flight JavaDoc command must run both main and test docs with `-Dshow=private`: many main classes and all test
 classes are package-private, and at javadoc's default `protected` visibility doclint silently skips them. Running from a


### PR DESCRIPTION
Smoothing the release runbook with the lessons from cutting 22.0.0.

- **`tools/preflight.ps1`** — runbook step 5 as one fail-fast command with honest exit codes and a final summary. (During 22.0.0, a `BUILD FAILURE` hid behind a green shell exit; caught only by log reading.)
- **`TestPgnCorpusFileStructure`** — the strict file-structure pre-scan over all 1386 corpus files (~0.2 s) in the *default* profile, so a malformed corpus file fails the commit that adds it, not release day. Negative-probe verified against the exact 22.0.0 defect (`*\n` instead of `*\n\n`).
- **workflows.md** — JavaDoc gates moved into cleanup step 2, step 5 rewritten around the script, fixture-adding procedure gains the structure-lint check.

Full default profile green with the new lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)